### PR TITLE
enhancement: evaluate and convert response types

### DIFF
--- a/connector/connector_test.go
+++ b/connector/connector_test.go
@@ -109,7 +109,7 @@ func TestHTTPConnector_emptyServer(t *testing.T) {
 func TestHTTPConnector_authentication(t *testing.T) {
 	apiKey := "random_api_key"
 	bearerToken := "random_bearer_token"
-	slog.SetLogLoggerLevel(slog.LevelDebug)
+	// slog.SetLogLoggerLevel(slog.LevelDebug)
 	server := createMockServer(t, apiKey, bearerToken)
 	defer server.Close()
 
@@ -831,7 +831,8 @@ func TestHTTPConnector_multiSchemas(t *testing.T) {
 	testServer := connServer.BuildTestServer()
 	defer testServer.Close()
 
-	slog.SetLogLoggerLevel(slog.LevelDebug)
+	// slog.SetLogLoggerLevel(slog.LevelDebug)
+
 	reqBody := []byte(`{
 			"collection": "findCats",
 			"query": {
@@ -1012,7 +1013,7 @@ func createMockServer(t *testing.T, apiKey string, bearerToken string) *httptest
 			assert.Equal(t, "test-client", result.CLientID)
 			assert.Equal(t, true, result.Active)
 
-			writeResponse(w, "{}")
+			writeResponse(w, "[{}]")
 		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
@@ -1275,7 +1276,7 @@ func TestConnectorOAuth(t *testing.T) {
 						"headers": map[string]any{
 							"Content-Type": string("application/json"),
 						},
-						"response": map[string]any{},
+						"response": []any{map[string]any{}},
 					},
 				},
 			},

--- a/connector/internal/client.go
+++ b/connector/internal/client.go
@@ -416,7 +416,7 @@ func (client *HTTPClient) evalHTTPResponse(ctx context.Context, span trace.Span,
 		}
 
 		var err error
-		result, err = contenttype.NewJSONDecoder(client.metadata.NDCHttpSchema).Decode(json.NewDecoder(resp.Body), responseType)
+		result, err = contenttype.NewJSONDecoder(client.metadata.NDCHttpSchema).Decode(resp.Body, responseType)
 		if err != nil {
 			return nil, nil, schema.NewConnectorError(http.StatusInternalServerError, err.Error(), nil)
 		}

--- a/connector/internal/client.go
+++ b/connector/internal/client.go
@@ -416,20 +416,16 @@ func (client *HTTPClient) evalHTTPResponse(ctx context.Context, span trace.Span,
 		}
 
 		var err error
-		result, err = contenttype.NewJSONDecoder(client.metadata.NDCHttpSchema).Decode(resp.Body, responseType)
+		result, err = contenttype.NewJSONDecoder(client.metadata.NDCHttpSchema).Decode(json.NewDecoder(resp.Body), responseType)
 		if err != nil {
 			return nil, nil, schema.NewConnectorError(http.StatusInternalServerError, err.Error(), nil)
 		}
 	case contentType == rest.ContentTypeNdJSON:
-		responseType, extractErr := client.extractResultType(resultType)
-		if extractErr != nil {
-			return nil, nil, extractErr
-		}
-
 		var results []any
 		decoder := json.NewDecoder(resp.Body)
 		for decoder.More() {
-			r, err := contenttype.NewJSONDecoder(client.metadata.NDCHttpSchema).Decode(resp.Body, responseType)
+			var r any
+			err := decoder.Decode(&r)
 			if err != nil {
 				return nil, nil, schema.NewConnectorError(http.StatusInternalServerError, err.Error(), nil)
 			}

--- a/connector/internal/contenttype/json.go
+++ b/connector/internal/contenttype/json.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -152,6 +153,14 @@ func (c *JSONDecoder) evalScalarType(value any, scalarType schema.ScalarType) (a
 		return utils.DecodeFloat[float64](value)
 	case *schema.TypeRepresentationInt8, *schema.TypeRepresentationInt16, *schema.TypeRepresentationInt32:
 		return utils.DecodeInt[int64](value)
+	case *schema.TypeRepresentationString:
+		if s, ok := value.(string); ok {
+			return s, nil
+		}
+
+		reflectType := reflect.ValueOf(value)
+
+		return StringifySimpleScalar(reflectType, reflectType.Kind())
 	default:
 		return value, nil
 	}

--- a/connector/internal/contenttype/json.go
+++ b/connector/internal/contenttype/json.go
@@ -3,6 +3,7 @@ package contenttype
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 
@@ -24,7 +25,7 @@ func NewJSONDecoder(httpSchema *rest.NDCHttpSchema) *JSONDecoder {
 }
 
 // Decode unmarshals json and evaluate the schema type.
-func (c *JSONDecoder) Decode(decoder *json.Decoder, resultType schema.Type) (any, error) {
+func (c *JSONDecoder) Decode(r io.Reader, resultType schema.Type) (any, error) {
 	underlyingType, _, err := UnwrapNullableType(resultType)
 	if err != nil {
 		return nil, err
@@ -33,7 +34,7 @@ func (c *JSONDecoder) Decode(decoder *json.Decoder, resultType schema.Type) (any
 	switch t := underlyingType.(type) {
 	case *schema.ArrayType:
 		var rawResult []any
-		err := decoder.Decode(&rawResult)
+		err := json.NewDecoder(r).Decode(&rawResult)
 		if err != nil {
 			return nil, err
 		}
@@ -45,7 +46,7 @@ func (c *JSONDecoder) Decode(decoder *json.Decoder, resultType schema.Type) (any
 		return c.evalArrayType(rawResult, t, []string{})
 	case *schema.NamedType:
 		var result any
-		err := decoder.Decode(&result)
+		err := json.NewDecoder(r).Decode(&result)
 		if err != nil {
 			return nil, err
 		}
@@ -57,7 +58,7 @@ func (c *JSONDecoder) Decode(decoder *json.Decoder, resultType schema.Type) (any
 		return c.evalNamedType(result, t, []string{})
 	default:
 		var result any
-		err := decoder.Decode(&result)
+		err := json.NewDecoder(r).Decode(&result)
 
 		return result, err
 	}

--- a/connector/internal/contenttype/json.go
+++ b/connector/internal/contenttype/json.go
@@ -3,7 +3,6 @@ package contenttype
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"strconv"
 	"strings"
 
@@ -25,7 +24,7 @@ func NewJSONDecoder(httpSchema *rest.NDCHttpSchema) *JSONDecoder {
 }
 
 // Decode unmarshals json and evaluate the schema type.
-func (c *JSONDecoder) Decode(r io.Reader, resultType schema.Type) (any, error) {
+func (c *JSONDecoder) Decode(decoder *json.Decoder, resultType schema.Type) (any, error) {
 	underlyingType, _, err := UnwrapNullableType(resultType)
 	if err != nil {
 		return nil, err
@@ -34,7 +33,7 @@ func (c *JSONDecoder) Decode(r io.Reader, resultType schema.Type) (any, error) {
 	switch t := underlyingType.(type) {
 	case *schema.ArrayType:
 		var rawResult []any
-		err := json.NewDecoder(r).Decode(&rawResult)
+		err := decoder.Decode(&rawResult)
 		if err != nil {
 			return nil, err
 		}
@@ -46,7 +45,7 @@ func (c *JSONDecoder) Decode(r io.Reader, resultType schema.Type) (any, error) {
 		return c.evalArrayType(rawResult, t, []string{})
 	case *schema.NamedType:
 		var result any
-		err := json.NewDecoder(r).Decode(&result)
+		err := decoder.Decode(&result)
 		if err != nil {
 			return nil, err
 		}
@@ -58,7 +57,7 @@ func (c *JSONDecoder) Decode(r io.Reader, resultType schema.Type) (any, error) {
 		return c.evalNamedType(result, t, []string{})
 	default:
 		var result any
-		err := json.NewDecoder(r).Decode(&result)
+		err := decoder.Decode(&result)
 
 		return result, err
 	}

--- a/connector/internal/contenttype/json.go
+++ b/connector/internal/contenttype/json.go
@@ -1,0 +1,158 @@
+package contenttype
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	rest "github.com/hasura/ndc-http/ndc-http-schema/schema"
+	"github.com/hasura/ndc-sdk-go/schema"
+	"github.com/hasura/ndc-sdk-go/utils"
+)
+
+// JSONDecoder implements a dynamic JSON decoder from the HTTP schema.
+type JSONDecoder struct {
+	schema *rest.NDCHttpSchema
+}
+
+// NewJSONDecoder creates a new JSON encoder.
+func NewJSONDecoder(httpSchema *rest.NDCHttpSchema) *JSONDecoder {
+	return &JSONDecoder{
+		schema: httpSchema,
+	}
+}
+
+// Decode unmarshals json and evaluate the schema type.
+func (c *JSONDecoder) Decode(r io.Reader, resultType schema.Type) (any, error) {
+	underlyingType, _, err := UnwrapNullableType(resultType)
+	if err != nil {
+		return nil, err
+	}
+
+	switch t := underlyingType.(type) {
+	case *schema.ArrayType:
+		var rawResult []any
+		err := json.NewDecoder(r).Decode(&rawResult)
+		if err != nil {
+			return nil, err
+		}
+
+		if utils.IsNil(rawResult) {
+			return nil, nil
+		}
+
+		return c.evalArrayType(rawResult, t, []string{})
+	case *schema.NamedType:
+		var result any
+		err := json.NewDecoder(r).Decode(&result)
+		if err != nil {
+			return nil, err
+		}
+
+		if utils.IsNil(result) {
+			return nil, nil
+		}
+
+		return c.evalNamedType(result, t, []string{})
+	default:
+		var result any
+		err := json.NewDecoder(r).Decode(&result)
+
+		return result, err
+	}
+}
+
+func (c *JSONDecoder) evalSchemaType(value any, schemaType schema.Type, fieldPaths []string) (any, error) {
+	if utils.IsNil(value) {
+		return nil, nil
+	}
+
+	switch t := schemaType.Interface().(type) {
+	case *schema.NullableType:
+		return c.evalSchemaType(value, t.UnderlyingType, fieldPaths)
+	case *schema.ArrayType:
+		return c.evalArrayType(value, t, fieldPaths)
+	case *schema.NamedType:
+		return c.evalNamedType(value, t, fieldPaths)
+	default:
+		return value, nil
+	}
+}
+
+func (c *JSONDecoder) evalArrayType(value any, arrayType *schema.ArrayType, fieldPaths []string) (any, error) {
+	arrayValue, ok := value.([]any)
+	if !ok {
+		return value, nil
+	}
+
+	results := make([]any, len(arrayValue))
+	for i, item := range arrayValue {
+		result, err := c.evalSchemaType(item, arrayType.ElementType, append(fieldPaths, strconv.Itoa(i)))
+		if err != nil {
+			return nil, err
+		}
+		results[i] = result
+	}
+
+	return results, nil
+}
+
+func (c *JSONDecoder) evalNamedType(value any, schemaType *schema.NamedType, fieldPaths []string) (any, error) {
+	scalarType, ok := c.schema.ScalarTypes[schemaType.Name]
+	if ok {
+		result, err := c.evalScalarType(value, scalarType)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", strings.Join(fieldPaths, "."), err)
+		}
+
+		return result, nil
+	}
+
+	objectType, ok := c.schema.ObjectTypes[schemaType.Name]
+	if !ok {
+		return value, nil
+	}
+
+	objectValue, ok := value.(map[string]any)
+	if !ok {
+		return value, nil
+	}
+
+	results := make(map[string]any)
+	for key, field := range objectType.Fields {
+		fieldValue, ok := objectValue[key]
+		if !ok {
+			continue
+		}
+
+		if fieldValue == nil {
+			results[key] = nil
+
+			continue
+		}
+
+		result, err := c.evalSchemaType(fieldValue, field.Type, append(fieldPaths, key))
+		if err != nil {
+			return nil, err
+		}
+
+		results[key] = result
+	}
+
+	return results, nil
+}
+
+func (c *JSONDecoder) evalScalarType(value any, scalarType schema.ScalarType) (any, error) {
+	switch scalarType.Representation.Interface().(type) {
+	case *schema.TypeRepresentationBoolean:
+		return utils.DecodeBoolean(value)
+	case *schema.TypeRepresentationFloat32, *schema.TypeRepresentationFloat64:
+		return utils.DecodeFloat[float64](value)
+	case *schema.TypeRepresentationInt8, *schema.TypeRepresentationInt16, *schema.TypeRepresentationInt32:
+		return utils.DecodeInt[int64](value)
+	default:
+		return value, nil
+	}
+}

--- a/connector/internal/contenttype/multipart.go
+++ b/connector/internal/contenttype/multipart.go
@@ -7,17 +7,10 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
-	"strings"
 
 	"github.com/hasura/ndc-http/ndc-http-schema/schema"
 	"github.com/hasura/ndc-sdk-go/utils"
 )
-
-var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
-
-func escapeQuotes(s string) string {
-	return quoteEscaper.Replace(s)
-}
 
 // MultipartWriter extends multipart.Writer with helpers
 type MultipartWriter struct {

--- a/connector/internal/contenttype/utils.go
+++ b/connector/internal/contenttype/utils.go
@@ -22,6 +22,8 @@ func StringifySimpleScalar(val reflect.Value, kind reflect.Kind) (string, error)
 		return val.String(), nil
 	case reflect.Bool:
 		return strconv.FormatBool(val.Bool()), nil
+	case reflect.Interface:
+		return fmt.Sprint(val.Interface()), nil
 	default:
 		value := val.Interface()
 		if stringer, ok := value.(fmt.Stringer); ok {

--- a/connector/internal/contenttype/utils.go
+++ b/connector/internal/contenttype/utils.go
@@ -1,6 +1,7 @@
 package contenttype
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -21,10 +22,18 @@ func StringifySimpleScalar(val reflect.Value, kind reflect.Kind) (string, error)
 		return val.String(), nil
 	case reflect.Bool:
 		return strconv.FormatBool(val.Bool()), nil
-	case reflect.Interface:
-		return fmt.Sprint(val.Interface()), nil
 	default:
-		return "", fmt.Errorf("invalid value: %v", val.Interface())
+		value := val.Interface()
+		if stringer, ok := value.(fmt.Stringer); ok {
+			return stringer.String(), nil
+		}
+
+		j, err := json.Marshal(value)
+		if err != nil {
+			return "", err
+		}
+
+		return string(j), nil
 	}
 }
 

--- a/connector/internal/contenttype/utils.go
+++ b/connector/internal/contenttype/utils.go
@@ -5,9 +5,16 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/hasura/ndc-sdk-go/schema"
 )
+
+var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
+
+func escapeQuotes(s string) string {
+	return quoteEscaper.Replace(s)
+}
 
 // StringifySimpleScalar converts a simple scalar value to string.
 func StringifySimpleScalar(val reflect.Value, kind reflect.Kind) (string, error) {

--- a/connector/internal/request_builder.go
+++ b/connector/internal/request_builder.go
@@ -449,7 +449,7 @@ func (c *RequestBuilder) getRequestUploadBody(rawRequest *rest.Request, bodyInfo
 		return rawRequest.RequestBody
 	}
 
-	bi, ok, err := UnwrapNullableType(bodyInfo.Type)
+	bi, ok, err := contenttype.UnwrapNullableType(bodyInfo.Type)
 	if err != nil || !ok {
 		return nil
 	}

--- a/connector/internal/request_builder_test.go
+++ b/connector/internal/request_builder_test.go
@@ -65,9 +65,7 @@ func TestCreateMultipartForm(t *testing.T) {
         }
       }`,
 			Expected: map[string]string{
-				"address.street":      `street 1`,
-				"address.location[0]": `0`,
-				"address.location[1]": `1`,
+				"address": `{"location":[0,1],"street":"street 1"}`,
 			},
 			ExpectedHeaders: map[string]http.Header{},
 		},

--- a/connector/internal/utils.go
+++ b/connector/internal/utils.go
@@ -1,33 +1,14 @@
 package internal
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/hasura/ndc-http/ndc-http-schema/utils"
-	"github.com/hasura/ndc-sdk-go/schema"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
-
-// UnwrapNullableType unwraps the underlying type of the nullable type
-func UnwrapNullableType(input schema.Type) (schema.TypeEncoder, bool, error) {
-	switch ty := input.Interface().(type) {
-	case *schema.NullableType:
-		childType, _, err := UnwrapNullableType(ty.UnderlyingType)
-		if err != nil {
-			return nil, false, err
-		}
-
-		return childType, true, nil
-	case *schema.NamedType, *schema.ArrayType:
-		return ty, false, nil
-	default:
-		return nil, false, fmt.Errorf("invalid type %v", input)
-	}
-}
 
 func setHeaderAttributes(span trace.Span, prefix string, httpHeaders http.Header) {
 	for key, headers := range httpHeaders {

--- a/connector/mutation.go
+++ b/connector/mutation.go
@@ -138,7 +138,7 @@ func (c *HTTPConnector) execMutationOperation(parentCtx context.Context, state *
 	}
 
 	httpOptions.Concurrency = c.config.Concurrency.HTTP
-	client := internal.NewHTTPClient(c.upstreams, metadata, c.config.ForwardHeaders, state.Tracer)
+	client := internal.NewHTTPClient(c.upstreams, metadata, c.config.ForwardHeaders)
 	result, _, err := client.Send(ctx, httpRequest, operation.Fields, procedure.ResultType, httpOptions)
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to execute mutation")

--- a/connector/query.go
+++ b/connector/query.go
@@ -153,7 +153,7 @@ func (c *HTTPConnector) execQuery(ctx context.Context, state *State, request *sc
 	}
 
 	httpOptions.Concurrency = c.config.Concurrency.HTTP
-	client := internal.NewHTTPClient(c.upstreams, metadata, c.config.ForwardHeaders, state.Tracer)
+	client := internal.NewHTTPClient(c.upstreams, metadata, c.config.ForwardHeaders)
 	result, _, err := client.Send(ctx, httpRequest, queryFields, function.ResultType, httpOptions)
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to execute the http request")

--- a/ndc-http-schema/configuration/convert.go
+++ b/ndc-http-schema/configuration/convert.go
@@ -35,7 +35,6 @@ func ConvertToNDCSchema(config *ConvertConfig, logger *slog.Logger) (*schema.NDC
 		NoDeprecation:       config.NoDeprecation,
 		Logger:              logger,
 	}
-	rawContent = utils.RemoveYAMLSpecialCharacters(rawContent)
 
 	switch config.Spec {
 	case schema.OpenAPIv3Spec, schema.OAS3Spec:

--- a/ndc-http-schema/openapi/internal/utils.go
+++ b/ndc-http-schema/openapi/internal/utils.go
@@ -231,7 +231,7 @@ func createSchemaFromOpenAPISchema(input *base.Schema) *rest.TypeSchema {
 	}
 	ps.Type = evaluateOpenAPITypes(input.Type)
 	ps.Format = input.Format
-	ps.Pattern = input.Pattern
+	ps.Pattern = utils.RemoveYAMLSpecialCharacters([]byte(input.Pattern))
 	ps.Maximum = input.Maximum
 	ps.Minimum = input.Minimum
 	ps.MaxLength = input.MaxLength

--- a/ndc-http-schema/openapi/oas2.go
+++ b/ndc-http-schema/openapi/oas2.go
@@ -11,7 +11,7 @@ import (
 
 // OpenAPIv2ToNDCSchema converts OpenAPI v2 JSON bytes to NDC HTTP schema
 func OpenAPIv2ToNDCSchema(input []byte, options ConvertOptions) (*rest.NDCHttpSchema, []error) {
-	input = utils.RemoveYAMLSpecialCharacters(input)
+	input = []byte(utils.RemoveYAMLSpecialCharacters(input))
 	document, err := libopenapi.NewDocument(input)
 	if err != nil {
 		return nil, []error{err}

--- a/ndc-http-schema/openapi/oas3.go
+++ b/ndc-http-schema/openapi/oas3.go
@@ -13,7 +13,7 @@ type ConvertOptions internal.ConvertOptions
 
 // OpenAPIv3ToNDCSchema converts OpenAPI v3 JSON bytes to NDC HTTP schema
 func OpenAPIv3ToNDCSchema(input []byte, options ConvertOptions) (*rest.NDCHttpSchema, []error) {
-	input = utils.RemoveYAMLSpecialCharacters(input)
+	input = []byte(utils.RemoveYAMLSpecialCharacters(input))
 	document, err := libopenapi.NewDocument(input)
 	if err != nil {
 		return nil, []error{err}

--- a/ndc-http-schema/utils/string.go
+++ b/ndc-http-schema/utils/string.go
@@ -196,7 +196,11 @@ func StripHTMLTags(str string) string {
 }
 
 // RemoveYAMLSpecialCharacters remote special characters to avoid YAML unmarshaling error
-func RemoveYAMLSpecialCharacters(input []byte) []byte {
+func RemoveYAMLSpecialCharacters(input []byte) string {
+	if len(input) == 0 {
+		return ""
+	}
+
 	var sb strings.Builder
 	inputLength := len(input)
 	for i := 0; i < inputLength; i++ {
@@ -212,10 +216,16 @@ func RemoveYAMLSpecialCharacters(input []byte) []byte {
 				i++
 			case 'u':
 				u := getu4(input[i:])
-				if u > -1 && utf8.ValidRune(u) {
-					sb.WriteRune(u)
+				if u > -1 {
+					i += 5
+				} else {
+					sb.WriteRune(r)
+					i++
 				}
-				i += 5
+			case '\\':
+				sb.WriteRune(r)
+				sb.WriteRune(r)
+				i++
 			default:
 				sb.WriteByte(c)
 			}
@@ -224,7 +234,7 @@ func RemoveYAMLSpecialCharacters(input []byte) []byte {
 		}
 	}
 
-	return []byte(strings.ToValidUTF8(sb.String(), ""))
+	return strings.ToValidUTF8(sb.String(), "")
 }
 
 // getu4 decodes \uXXXX from the beginning of s, returning the hex value,

--- a/ndc-http-schema/utils/string_test.go
+++ b/ndc-http-schema/utils/string_test.go
@@ -13,7 +13,11 @@ func TestRemoveYAMLSpecialCharacters(t *testing.T) {
 	}{
 		{
 			Input:    "\b\t\u0009Some\u0000thing\\u0002",
-			Expected: "  Something",
+			Expected: "  Something",
+		},
+		{
+			Input:    "^[a-zA-Z\\u0080-\\u024F\\s\\/\\-\\)\\(\\`\\.\\\"\\']+$",
+			Expected: "^[a-zA-Z-\\s\\/\\-\\)\\(\\`\\.\\\"\\']+$",
 		},
 	}
 


### PR DESCRIPTION
Evaluate the response and convert number scalar types if possible.
Some OpenAPI document declares the field as [an integer](https://github.com/hasura/ndc-http-recipes/blob/ae9ffeb3d2ecb0ffbbeccb1e2417da836ed16de4/recipes/collegefootballdata/v1/schema/collegefootballdata.json#L15422) but the API service returns [a stringified number](https://github.com/hasura/ndc-http-recipes/blob/ae9ffeb3d2ecb0ffbbeccb1e2417da836ed16de4/recipes/collegefootballdata/v1/testdata/query/playerSearch/expected.json#L10).