### PR TITLE
fix missing scalar alias generation, add Accept header and improve response decoding

### DIFF
--- a/connector/connector_test.go
+++ b/connector/connector_test.go
@@ -143,7 +143,7 @@ func TestHTTPConnector_authentication(t *testing.T) {
 		assertHTTPResponse(t, res, http.StatusOK, schema.ExplainResponse{
 			Details: schema.ExplainResponseDetails{
 				"url":     server.URL + "/pet",
-				"headers": `{"Api_key":["ran*******(14)"],"Content-Type":["application/json"]}`,
+				"headers": `{"Accept":["application/json"],"Api_key":["ran*******(14)"],"Content-Type":["application/json"]}`,
 			},
 		})
 	})
@@ -201,7 +201,7 @@ func TestHTTPConnector_authentication(t *testing.T) {
 		assertHTTPResponse(t, res, http.StatusOK, schema.ExplainResponse{
 			Details: schema.ExplainResponseDetails{
 				"url":     server.URL + "/pet",
-				"headers": `{"Api_key":["ran*******(14)"],"Content-Type":["application/json"]}`,
+				"headers": `{"Accept":["application/json"],"Api_key":["ran*******(14)"],"Content-Type":["application/json"]}`,
 				"body":    `{"name":"pet"}`,
 			},
 		})
@@ -253,7 +253,7 @@ func TestHTTPConnector_authentication(t *testing.T) {
 		assertHTTPResponse(t, res, http.StatusOK, schema.ExplainResponse{
 			Details: schema.ExplainResponseDetails{
 				"url":     server.URL + "/pet/findByStatus?status=available",
-				"headers": `{"Authorization":["Bearer ran*******(19)"],"Content-Type":["application/json"],"X-Custom-Header":["This is a test"]}`,
+				"headers": `{"Accept":["application/json"],"Authorization":["Bearer ran*******(19)"],"Content-Type":["application/json"],"X-Custom-Header":["This is a test"]}`,
 			},
 		})
 	})

--- a/connector/internal/client.go
+++ b/connector/internal/client.go
@@ -373,7 +373,7 @@ func (client *HTTPClient) evalHTTPResponse(ctx context.Context, span trace.Span,
 		}
 
 		result = string(respBody)
-	case contentType == rest.ContentTypeXML:
+	case contentType == rest.ContentTypeXML || strings.HasSuffix(contentType, "+xml"):
 		field, extractErr := client.extractResultType(resultType)
 		if extractErr != nil {
 			return nil, nil, extractErr
@@ -384,7 +384,7 @@ func (client *HTTPClient) evalHTTPResponse(ctx context.Context, span trace.Span,
 		if err != nil {
 			return nil, nil, schema.NewConnectorError(http.StatusInternalServerError, err.Error(), nil)
 		}
-	case contentType == rest.ContentTypeJSON:
+	case contentType == rest.ContentTypeJSON || strings.HasSuffix(contentType, "+json"):
 		if len(resultType) > 0 {
 			namedType, err := resultType.AsNamed()
 			if err == nil && namedType.Name == string(rest.ScalarString) {

--- a/connector/internal/request_builder.go
+++ b/connector/internal/request_builder.go
@@ -57,7 +57,7 @@ func (c *RequestBuilder) Build() (*RetryableRequest, error) {
 	}
 
 	if rawRequest.Response.ContentType != "" && request.Headers.Get(acceptHeader) == "" {
-		request.Headers.Set(acceptHeader, rawRequest.Response.ContentType)
+		request.Headers.Set(acceptHeader, evalAcceptContentType(rawRequest.Response.ContentType))
 	}
 
 	if rawRequest.RuntimeSettings != nil {

--- a/connector/internal/request_builder.go
+++ b/connector/internal/request_builder.go
@@ -56,6 +56,10 @@ func (c *RequestBuilder) Build() (*RetryableRequest, error) {
 		return nil, err
 	}
 
+	if rawRequest.Response.ContentType != "" && request.Headers.Get(acceptHeader) == "" {
+		request.Headers.Set(acceptHeader, rawRequest.Response.ContentType)
+	}
+
 	if rawRequest.RuntimeSettings != nil {
 		if rawRequest.RuntimeSettings.Timeout > 0 {
 			request.Runtime.Timeout = rawRequest.RuntimeSettings.Timeout

--- a/connector/internal/types.go
+++ b/connector/internal/types.go
@@ -31,7 +31,6 @@ type HTTPOptions struct {
 	Servers  []string `json:"serverIds" yaml:"serverIds"`
 	Parallel bool     `json:"parallel"  yaml:"parallel"`
 
-	Explain     bool `json:"-" yaml:"-"`
 	Distributed bool `json:"-" yaml:"-"`
 	Concurrency uint `json:"-" yaml:"-"`
 }

--- a/connector/internal/types.go
+++ b/connector/internal/types.go
@@ -12,6 +12,7 @@ import (
 )
 
 const (
+	acceptHeader               = "Accept"
 	contentTypeHeader          = "Content-Type"
 	defaultTimeoutSeconds uint = 30
 	defaultRetryDelays    uint = 1000

--- a/connector/internal/utils.go
+++ b/connector/internal/utils.go
@@ -10,13 +10,29 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// IsSensitiveHeader checks if the header name is sensitive.
+func IsSensitiveHeader(name string) bool {
+	return sensitiveHeaderRegex.MatchString(strings.ToLower(name))
+}
+
+func evalAcceptContentType(contentType string) string {
+	switch {
+	case strings.HasPrefix(contentType, "image/"):
+		return "image/*"
+	case strings.HasPrefix(contentType, "video/"):
+		return "video/*"
+	default:
+		return contentType
+	}
+}
+
 func setHeaderAttributes(span trace.Span, prefix string, httpHeaders http.Header) {
 	for key, headers := range httpHeaders {
 		if len(headers) == 0 {
 			continue
 		}
 		values := headers
-		if sensitiveHeaderRegex.MatchString(strings.ToLower(key)) {
+		if IsSensitiveHeader(key) {
 			values = make([]string, len(headers))
 			for i, header := range headers {
 				values[i] = utils.MaskString(header)

--- a/connector/internal/utils_test.go
+++ b/connector/internal/utils_test.go
@@ -1,0 +1,13 @@
+package internal
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestEvalAcceptContentType(t *testing.T) {
+	assert.Equal(t, "image/*", evalAcceptContentType("image/jpeg"))
+	assert.Equal(t, "video/*", evalAcceptContentType("video/mp4"))
+	assert.Equal(t, "application/json", evalAcceptContentType("application/json"))
+}

--- a/connector/query.go
+++ b/connector/query.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hasura/ndc-http/connector/internal"
 	"github.com/hasura/ndc-http/ndc-http-schema/configuration"
+	restUtils "github.com/hasura/ndc-http/ndc-http-schema/utils"
 	"github.com/hasura/ndc-sdk-go/schema"
 	"github.com/hasura/ndc-sdk-go/utils"
 	"go.opentelemetry.io/otel/codes"
@@ -174,6 +175,13 @@ func (c *HTTPConnector) serializeExplainResponse(ctx context.Context, requests *
 		return nil, err
 	}
 	defer cancel()
+
+	// mask sensitive forwarded headers if exists
+	for key := range req.Header {
+		if internal.IsSensitiveHeader(key) {
+			req.Header.Set(key, restUtils.MaskString(req.Header.Get(key)))
+		}
+	}
 
 	c.upstreams.InjectMockRequestSettings(req, requests.Schema.Name, httpRequest.RawRequest.Security)
 

--- a/ndc-http-schema/openapi/internal/oas3.go
+++ b/ndc-http-schema/openapi/internal/oas3.go
@@ -262,6 +262,10 @@ func (oc *OAS3Builder) convertComponentSchemas(schemaItem orderedmap.Pair[string
 	if _, ok := oc.schema.ObjectTypes[typeKey]; ok {
 		return nil
 	}
+	if _, ok := oc.schema.ScalarTypes[typeKey]; ok {
+		return nil
+	}
+
 	typeEncoder, schemaResult, err := newOAS3SchemaBuilder(oc, "", rest.InBody, false).
 		getSchemaType(typeSchema, []string{typeKey})
 	if err != nil {
@@ -280,6 +284,13 @@ func (oc *OAS3Builder) convertComponentSchemas(schemaItem orderedmap.Pair[string
 		if schemaResult.XML.Name == "" {
 			schemaResult.XML.Name = typeKey
 		}
+	}
+
+	// If the result type is a scalar, the builder returns the raw scalar name (String, Int).
+	// We should check and add the alias type to scalar objects
+	pascalTypeName := utils.ToPascalCase(typeKey)
+	if scalarType, ok := oc.schema.ScalarTypes[typeName]; ok && pascalTypeName != typeName {
+		oc.schema.ScalarTypes[pascalTypeName] = scalarType
 	}
 
 	cacheKey := "#/components/schemas/" + typeKey

--- a/ndc-http-schema/openapi/testdata/petstore2/expected.json
+++ b/ndc-http-schema/openapi/testdata/petstore2/expected.json
@@ -564,6 +564,38 @@
         "type": "named"
       }
     },
+    "get_subject": {
+      "request": {
+        "url": "/id/{identifier}",
+        "method": "get",
+        "response": {
+          "contentType": "application/json"
+        }
+      },
+      "arguments": {
+        "identifier": {
+          "description": "The identifier path of the `subject` you're looking for",
+          "type": {
+            "name": "String",
+            "type": "named"
+          },
+          "http": {
+            "name": "identifier",
+            "in": "path",
+            "schema": {
+              "type": [
+                "string"
+              ]
+            }
+          }
+        }
+      },
+      "description": "Explore details about a given subject node",
+      "result_type": {
+        "name": "JSON",
+        "type": "named"
+      }
+    },
     "listOAuth2Clients": {
       "request": {
         "url": "/clients",

--- a/ndc-http-schema/openapi/testdata/petstore2/schema.json
+++ b/ndc-http-schema/openapi/testdata/petstore2/schema.json
@@ -262,6 +262,23 @@
     },
     {
       "arguments": {
+        "identifier": {
+          "description": "The identifier path of the `subject` you're looking for",
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        }
+      },
+      "description": "Explore details about a given subject node",
+      "name": "get_subject",
+      "result_type": {
+        "name": "JSON",
+        "type": "named"
+      }
+    },
+    {
+      "arguments": {
         "client_name": {
           "description": "The name of the clients to filter by.",
           "type": {

--- a/ndc-http-schema/openapi/testdata/petstore2/swagger.json
+++ b/ndc-http-schema/openapi/testdata/petstore2/swagger.json
@@ -904,6 +904,30 @@
           }
         ]
       }
+    },
+    "/id/{identifier}": {
+      "get": {
+        "operationId": "get subject",
+        "parameters": [
+          {
+            "description": "The identifier path of the `subject` you're looking for\n",
+            "in": "path",
+            "name": "identifier",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": ["text/html", "application/ld+json", "application/json"],
+        "responses": {
+          "200": {
+            "description": "`subject` found\n"
+          },
+          "404": {
+            "description": "`subject` not found\n"
+          }
+        },
+        "summary": "Explore details about a given subject node"
+      }
     }
   },
   "securityDefinitions": {


### PR DESCRIPTION
- Fix missing scalar type alias from primitive scalars.
- Add the `Accept` request header with the value from the response content type.
- Decode the response in JSON/XML format if the content type contains `+json` or `+xml` suffix.
- Mask sensitive headers that are forwarded from the v3-engine 