### PR TITLE
fix: incorrect urlencode encoding for JSON scalar, argument preset init

### DIFF
--- a/connector/connector_test.go
+++ b/connector/connector_test.go
@@ -202,7 +202,7 @@ func TestHTTPConnector_authentication(t *testing.T) {
 			Details: schema.ExplainResponseDetails{
 				"url":     server.URL + "/pet",
 				"headers": `{"Accept":["application/json"],"Api_key":["ran*******(14)"],"Content-Type":["application/json"]}`,
-				"body":    `{"name":"pet"}`,
+				"body":    "{\"name\":\"pet\"}\n",
 			},
 		})
 	})
@@ -380,7 +380,7 @@ func TestHTTPConnector_authentication(t *testing.T) {
 
 		res, err := http.Post(fmt.Sprintf("%s/query", testServer.URL), "application/json", bytes.NewBuffer(reqBody))
 		assert.NilError(t, err)
-		assert.Equal(t, http.StatusTooManyRequests, res.StatusCode)
+		assert.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
 	})
 
 	t.Run("encoding-ndjson", func(t *testing.T) {

--- a/connector/internal/argument/preset.go
+++ b/connector/internal/argument/preset.go
@@ -18,8 +18,8 @@ type ArgumentPreset struct {
 }
 
 // NewArgumentPreset create a new ArgumentPreset instance.
-func NewArgumentPreset(httpSchema *rest.NDCHttpSchema, preset rest.ArgumentPresetConfig) (*ArgumentPreset, error) {
-	jsonPath, targets, err := configuration.ValidateArgumentPreset(httpSchema, preset)
+func NewArgumentPreset(httpSchema *rest.NDCHttpSchema, preset rest.ArgumentPresetConfig, isGlobal bool) (*ArgumentPreset, error) {
+	jsonPath, targets, err := configuration.ValidateArgumentPreset(httpSchema, preset, isGlobal)
 	if err != nil {
 		return nil, err
 	}

--- a/connector/internal/argument/presets.go
+++ b/connector/internal/argument/presets.go
@@ -13,13 +13,13 @@ type ArgumentPresets struct {
 }
 
 // NewArgumentPresets create a new ArgumentPresets instance.
-func NewArgumentPresets(httpSchema *rest.NDCHttpSchema, presets []rest.ArgumentPresetConfig) (*ArgumentPresets, error) {
+func NewArgumentPresets(httpSchema *rest.NDCHttpSchema, presets []rest.ArgumentPresetConfig, isGlobal bool) (*ArgumentPresets, error) {
 	result := &ArgumentPresets{
 		httpSchema: httpSchema,
 		presets:    nil,
 	}
 	for i, item := range presets {
-		preset, err := NewArgumentPreset(httpSchema, item)
+		preset, err := NewArgumentPreset(httpSchema, item, isGlobal)
 		if err != nil {
 			return nil, fmt.Errorf("%d: %w", i, err)
 		}

--- a/connector/internal/client.go
+++ b/connector/internal/client.go
@@ -248,7 +248,12 @@ func (client *HTTPClient) sendSingle(ctx context.Context, request *RetryableRequ
 
 		span.SetStatus(codes.Error, "received error from remote server")
 
-		return nil, nil, schema.NewConnectorError(resp.StatusCode, resp.Status, details)
+		statusCode := resp.StatusCode
+		if statusCode < 500 {
+			statusCode = http.StatusUnprocessableEntity
+		}
+
+		return nil, nil, schema.NewConnectorError(statusCode, resp.Status, details)
 	}
 
 	result, headers, evalErr := client.evalHTTPResponse(ctx, span, resp, contentType, selection, logger)

--- a/connector/internal/contenttype/multipart.go
+++ b/connector/internal/contenttype/multipart.go
@@ -23,7 +23,7 @@ type MultipartFormEncoder struct {
 func NewMultipartFormEncoder(schema *rest.NDCHttpSchema, operation *rest.OperationInfo, arguments map[string]any) *MultipartFormEncoder {
 	return &MultipartFormEncoder{
 		schema:       schema,
-		paramEncoder: NewURLParameterEncoder(schema),
+		paramEncoder: NewURLParameterEncoder(schema, rest.ContentTypeMultipartFormData),
 		operation:    operation,
 		arguments:    arguments,
 	}

--- a/connector/internal/contenttype/url_encode.go
+++ b/connector/internal/contenttype/url_encode.go
@@ -21,12 +21,16 @@ import (
 
 // URLParameterEncoder represents a URL parameter encoder.
 type URLParameterEncoder struct {
-	schema *rest.NDCHttpSchema
+	schema      *rest.NDCHttpSchema
+	contentType string
 }
 
 // NewURLParameterEncoder creates a URLParameterEncoder instance.
-func NewURLParameterEncoder(schema *rest.NDCHttpSchema) *URLParameterEncoder {
-	return &URLParameterEncoder{schema: schema}
+func NewURLParameterEncoder(schema *rest.NDCHttpSchema, contentType string) *URLParameterEncoder {
+	return &URLParameterEncoder{
+		schema:      schema,
+		contentType: contentType,
+	}
 }
 
 func (c *URLParameterEncoder) Encode(bodyInfo *rest.ArgumentInfo, bodyData any) (io.ReadSeeker, error) {
@@ -104,7 +108,7 @@ func (c *URLParameterEncoder) EncodeParameterValues(objectField *rest.ObjectFiel
 		}
 		iScalar, ok := c.schema.ScalarTypes[ty.Name]
 		if ok {
-			return encodeScalarParameterReflectionValues(reflectValue, &iScalar, fieldPaths)
+			return c.encodeScalarParameterReflectionValues(reflectValue, &iScalar, fieldPaths)
 		}
 		kind := reflectValue.Kind()
 		objectInfo, ok := c.schema.ObjectTypes[ty.Name]
@@ -160,7 +164,7 @@ func (c *URLParameterEncoder) EncodeParameterValues(objectField *rest.ObjectFiel
 	return nil, fmt.Errorf("%s: invalid type %v", strings.Join(fieldPaths, ""), objectField.Type)
 }
 
-func encodeScalarParameterReflectionValues(reflectValue reflect.Value, scalar *schema.ScalarType, fieldPaths []string) (ParameterItems, error) {
+func (c *URLParameterEncoder) encodeScalarParameterReflectionValues(reflectValue reflect.Value, scalar *schema.ScalarType, fieldPaths []string) (ParameterItems, error) {
 	switch sl := scalar.Representation.Interface().(type) {
 	case *schema.TypeRepresentationBoolean:
 		value, err := utils.DecodeBooleanReflection(reflectValue)
@@ -238,24 +242,32 @@ func encodeScalarParameterReflectionValues(reflectValue reflect.Value, scalar *s
 
 		return []ParameterItem{NewParameterItem([]Key{}, []string{rawValue})}, nil
 	default:
-		return encodeParameterReflectionValues(reflectValue, fieldPaths)
+		return c.encodeParameterReflectionValues(reflectValue, fieldPaths)
 	}
 }
 
-func encodeParameterReflectionValues(reflectValue reflect.Value, fieldPaths []string) (ParameterItems, error) {
+func (c *URLParameterEncoder) encodeParameterReflectionValues(reflectValue reflect.Value, fieldPaths []string) (ParameterItems, error) {
 	reflectValue, ok := utils.UnwrapPointerFromReflectValue(reflectValue)
 	if !ok {
 		return ParameterItems{}, nil
 	}
 
 	kind := reflectValue.Kind()
+	if c.contentType == rest.ContentTypeMultipartFormData {
+		if result, err := StringifySimpleScalar(reflectValue, kind); err == nil {
+			return []ParameterItem{
+				NewParameterItem([]Key{}, []string{result}),
+			}, nil
+		}
+	}
+
 	switch kind {
 	case reflect.Slice, reflect.Array:
-		return encodeParameterReflectionSlice(reflectValue, fieldPaths)
+		return c.encodeParameterReflectionSlice(reflectValue, fieldPaths)
 	case reflect.Map, reflect.Interface:
-		return encodeParameterReflectionMap(reflectValue, fieldPaths)
+		return c.encodeParameterReflectionMap(reflectValue, fieldPaths)
 	case reflect.Struct:
-		return encodeParameterReflectionStruct(reflectValue, fieldPaths)
+		return c.encodeParameterReflectionStruct(reflectValue, fieldPaths)
 	default:
 		if result, err := StringifySimpleScalar(reflectValue, kind); err == nil {
 			return []ParameterItem{
@@ -267,12 +279,12 @@ func encodeParameterReflectionValues(reflectValue reflect.Value, fieldPaths []st
 	}
 }
 
-func encodeParameterReflectionSlice(reflectValue reflect.Value, fieldPaths []string) (ParameterItems, error) {
+func (c *URLParameterEncoder) encodeParameterReflectionSlice(reflectValue reflect.Value, fieldPaths []string) (ParameterItems, error) {
 	results := ParameterItems{}
 	valueLen := reflectValue.Len()
 	for i := range valueLen {
 		elem := reflectValue.Index(i)
-		outputs, err := encodeParameterReflectionValues(elem, append(fieldPaths, fmt.Sprintf("[%d]", i)))
+		outputs, err := c.encodeParameterReflectionValues(elem, append(fieldPaths, fmt.Sprintf("[%d]", i)))
 		if err != nil {
 			return nil, err
 		}
@@ -285,13 +297,13 @@ func encodeParameterReflectionSlice(reflectValue reflect.Value, fieldPaths []str
 	return results, nil
 }
 
-func encodeParameterReflectionStruct(reflectValue reflect.Value, fieldPaths []string) (ParameterItems, error) {
+func (c *URLParameterEncoder) encodeParameterReflectionStruct(reflectValue reflect.Value, fieldPaths []string) (ParameterItems, error) {
 	results := ParameterItems{}
 	reflectType := reflectValue.Type()
 	for fieldIndex := range reflectValue.NumField() {
 		fieldVal := reflectValue.Field(fieldIndex)
 		fieldType := reflectType.Field(fieldIndex)
-		output, err := encodeParameterReflectionValues(fieldVal, append(fieldPaths, "."+fieldType.Name))
+		output, err := c.encodeParameterReflectionValues(fieldVal, append(fieldPaths, "."+fieldType.Name))
 		if err != nil {
 			return nil, err
 		}
@@ -304,7 +316,7 @@ func encodeParameterReflectionStruct(reflectValue reflect.Value, fieldPaths []st
 	return results, nil
 }
 
-func encodeParameterReflectionMap(reflectValue reflect.Value, fieldPaths []string) (ParameterItems, error) {
+func (c *URLParameterEncoder) encodeParameterReflectionMap(reflectValue reflect.Value, fieldPaths []string) (ParameterItems, error) {
 	results := ParameterItems{}
 	anyValue := reflectValue.Interface()
 	object, ok := anyValue.(map[string]any)
@@ -319,7 +331,7 @@ func encodeParameterReflectionMap(reflectValue reflect.Value, fieldPaths []strin
 	}
 
 	for key, fieldValue := range object {
-		output, err := encodeParameterReflectionValues(reflect.ValueOf(fieldValue), append(fieldPaths, "."+key))
+		output, err := c.encodeParameterReflectionValues(reflect.ValueOf(fieldValue), append(fieldPaths, "."+key))
 		if err != nil {
 			return nil, err
 		}

--- a/connector/internal/contenttype/url_encode.go
+++ b/connector/internal/contenttype/url_encode.go
@@ -119,6 +119,7 @@ func (c *URLParameterEncoder) EncodeParameterValues(objectField *rest.ObjectFiel
 			if !ok {
 				return nil, fmt.Errorf("%s: failed to evaluate object, got <%s> %v", strings.Join(fieldPaths, ""), kind, anyValue)
 			}
+
 			for key, fieldInfo := range objectInfo.Fields {
 				fieldVal := object[key]
 				output, err := c.EncodeParameterValues(&fieldInfo, reflect.ValueOf(fieldVal), append(fieldPaths, "."+key))
@@ -248,12 +249,6 @@ func encodeParameterReflectionValues(reflectValue reflect.Value, fieldPaths []st
 	}
 
 	kind := reflectValue.Kind()
-	if result, err := StringifySimpleScalar(reflectValue, kind); err == nil {
-		return []ParameterItem{
-			NewParameterItem([]Key{}, []string{result}),
-		}, nil
-	}
-
 	switch kind {
 	case reflect.Slice, reflect.Array:
 		return encodeParameterReflectionSlice(reflectValue, fieldPaths)
@@ -262,6 +257,12 @@ func encodeParameterReflectionValues(reflectValue reflect.Value, fieldPaths []st
 	case reflect.Struct:
 		return encodeParameterReflectionStruct(reflectValue, fieldPaths)
 	default:
+		if result, err := StringifySimpleScalar(reflectValue, kind); err == nil {
+			return []ParameterItem{
+				NewParameterItem([]Key{}, []string{result}),
+			}, nil
+		}
+
 		return nil, fmt.Errorf("%s: failed to encode parameter, got %s", strings.Join(fieldPaths, ""), kind)
 	}
 }

--- a/connector/internal/contenttype/url_encode_test.go
+++ b/connector/internal/contenttype/url_encode_test.go
@@ -691,7 +691,7 @@ func TestCreateFormURLEncoded(t *testing.T) {
 			var arguments map[string]any
 			assert.NilError(t, json.Unmarshal([]byte(tc.RawArguments), &arguments))
 			argumentInfo := info.Arguments["body"]
-			builder := NewURLParameterEncoder(ndcSchema)
+			builder := NewURLParameterEncoder(ndcSchema, rest.ContentTypeFormURLEncoded)
 			buf, err := builder.Encode(&argumentInfo, arguments["body"])
 			assert.NilError(t, err)
 			result, err := io.ReadAll(buf)

--- a/connector/internal/request_builder.go
+++ b/connector/internal/request_builder.go
@@ -137,14 +137,16 @@ func (c *RequestBuilder) buildRequestBody(request *RetryableRequest, rawRequest 
 
 			return nil
 		case contentType == rest.ContentTypeJSON || contentType == "":
+			var buf bytes.Buffer
+			enc := json.NewEncoder(&buf)
+			enc.SetEscapeHTML(false)
 
-			bodyBytes, err := json.Marshal(bodyData)
-			if err != nil {
+			if err := enc.Encode(bodyData); err != nil {
 				return err
 			}
 
-			request.ContentLength = int64(len(bodyBytes))
-			request.Body = bytes.NewReader(bodyBytes)
+			request.ContentLength = int64(buf.Len())
+			request.Body = bytes.NewReader(buf.Bytes())
 
 			return nil
 		case contentType == rest.ContentTypeXML:

--- a/connector/internal/request_builder.go
+++ b/connector/internal/request_builder.go
@@ -129,7 +129,7 @@ func (c *RequestBuilder) buildRequestBody(request *RetryableRequest, rawRequest 
 
 			return nil
 		case contentType == rest.ContentTypeFormURLEncoded:
-			r, err := contenttype.NewURLParameterEncoder(c.Schema).Encode(&bodyInfo, bodyData)
+			r, err := contenttype.NewURLParameterEncoder(c.Schema, rest.ContentTypeFormURLEncoded).Encode(&bodyInfo, bodyData)
 			if err != nil {
 				return err
 			}
@@ -237,7 +237,7 @@ func (c *RequestBuilder) evalURLAndHeaderParameterBySchema(endpoint *url.URL, he
 	if argumentInfo.HTTP.Name != "" {
 		argumentKey = argumentInfo.HTTP.Name
 	}
-	queryParams, err := contenttype.NewURLParameterEncoder(c.Schema).EncodeParameterValues(&rest.ObjectField{
+	queryParams, err := contenttype.NewURLParameterEncoder(c.Schema, rest.ContentTypeFormURLEncoded).EncodeParameterValues(&rest.ObjectField{
 		ObjectField: schema.ObjectField{
 			Type: argumentInfo.Type,
 		},

--- a/connector/internal/security/auth.go
+++ b/connector/internal/security/auth.go
@@ -28,15 +28,15 @@ func NewCredential(ctx context.Context, httpClient *http.Client, security schema
 	case *schema.APIKeyAuthConfig:
 		cred, err := NewApiKeyCredential(httpClient, ss)
 
-		return cred, err == nil, err
+		return cred, err != nil, err
 	case *schema.BasicAuthConfig:
 		cred, err := NewBasicCredential(httpClient, ss)
 
-		return cred, err == nil, err
+		return cred, err != nil, err
 	case *schema.HTTPAuthConfig:
 		cred, err := NewHTTPCredential(httpClient, ss)
 
-		return cred, err == nil, err
+		return cred, err != nil, err
 	case *schema.OAuth2Config:
 		var headerForwardingRequired bool
 		for flowType, flow := range ss.Flows {

--- a/connector/internal/upstream.go
+++ b/connector/internal/upstream.go
@@ -58,7 +58,7 @@ func (um *UpstreamManager) Register(ctx context.Context, runtimeSchema *configur
 	}
 
 	if len(runtimeSchema.Settings.ArgumentPresets) > 0 {
-		argumentPresets, err := argument.NewArgumentPresets(ndcSchema, runtimeSchema.Settings.ArgumentPresets)
+		argumentPresets, err := argument.NewArgumentPresets(ndcSchema, runtimeSchema.Settings.ArgumentPresets, true)
 		if err != nil {
 			return fmt.Errorf("%s: %w", namespace, err)
 		}
@@ -101,7 +101,7 @@ func (um *UpstreamManager) Register(ctx context.Context, runtimeSchema *configur
 		}
 
 		if len(server.ArgumentPresets) > 0 {
-			argumentPresets, err := argument.NewArgumentPresets(ndcSchema, server.ArgumentPresets)
+			argumentPresets, err := argument.NewArgumentPresets(ndcSchema, server.ArgumentPresets, false)
 			if err != nil {
 				return fmt.Errorf("%s.server[%s]: %w", namespace, serverID, err)
 			}

--- a/connector/testdata/presets/petstore.json
+++ b/connector/testdata/presets/petstore.json
@@ -14,6 +14,14 @@
               "name": "PET_NAME"
             },
             "targets": ["addPet"]
+          },
+          {
+            "path": "kind",
+            "value": {
+              "type": "literal",
+              "value": "test"
+            },
+            "targets": []
           }
         ]
       }
@@ -55,6 +63,18 @@
               "name": "String",
               "type": "named"
             }
+          },
+          "http": {
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        },
+        "kind": {
+          "type": {
+            "name": "String",
+            "type": "named"
           },
           "http": {
             "in": "query",

--- a/connector/testdata/presets/schema.json
+++ b/connector/testdata/presets/schema.json
@@ -9,6 +9,15 @@
             "type": "nullable",
             "underlying_type": { "name": "JSON", "type": "named" }
           }
+        },
+        "kind": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
         }
       },
       "description": "Finds Pets by status",

--- a/ndc-http-schema/command/testdata/auth/expected.json
+++ b/ndc-http-schema/command/testdata/auth/expected.json
@@ -6,52 +6,7 @@
         {
           "url": {
             "env": "PET_STORE_URL"
-          },
-          "securitySchemes": {
-            "api_key": {
-              "type": "apiKey",
-              "in": "header",
-              "name": "api_key",
-              "value": {
-                "env": "PET_STORE_API_KEY"
-              }
-            },
-            "basic": {
-              "type": "basic",
-              "header": "Authorization",
-              "username": {
-                "value": "user"
-              },
-              "password": {
-                "value": "password"
-              }
-            },
-            "bearer": {
-              "type": "http",
-              "header": "",
-              "scheme": "bearer",
-              "value": {
-                "env": "PET_STORE_BEARER_TOKEN"
-              }
-            },
-            "petstore_auth": {
-              "type": "oauth2",
-              "flows": {
-                "implicit": {
-                  "authorizationUrl": "https://petstore3.swagger.io/oauth/authorize",
-                  "scopes": {
-                    "read:pets": "read your pets",
-                    "write:pets": "modify pets in your account"
-                  }
-                }
-              }
-            }
-          },
-          "security": [
-            {
-              "api_key": []
-            }
-          ]
+          }
         }
       ],
       "securitySchemes": {

--- a/ndc-http-schema/command/testdata/patch/expected.json
+++ b/ndc-http-schema/command/testdata/patch/expected.json
@@ -16,31 +16,8 @@
               "value": {
                 "value": "dog-secret"
               }
-            },
-            "basic": {
-              "type": "basic",
-              "header": "Authorization",
-              "username": {
-                "value": "user"
-              },
-              "password": {
-                "value": "password"
-              }
-            },
-            "bearer": {
-              "type": "http",
-              "header": "",
-              "scheme": "bearer",
-              "value": {
-                "env": "PET_STORE_BEARER_TOKEN"
-              }
             }
-          },
-          "security": [
-            {
-              "api_key": []
-            }
-          ]
+          }
         },
         {
           "url": {
@@ -55,31 +32,8 @@
               "value": {
                 "value": "cat-secret"
               }
-            },
-            "basic": {
-              "type": "basic",
-              "header": "Authorization",
-              "username": {
-                "value": "user"
-              },
-              "password": {
-                "value": "password"
-              }
-            },
-            "bearer": {
-              "type": "http",
-              "header": "",
-              "scheme": "bearer",
-              "value": {
-                "env": "PET_STORE_BEARER_TOKEN"
-              }
             }
-          },
-          "security": [
-            {
-              "api_key": []
-            }
-          ]
+          }
         }
       ],
       "securitySchemes": {

--- a/ndc-http-schema/configuration/argument_presets.go
+++ b/ndc-http-schema/configuration/argument_presets.go
@@ -91,6 +91,10 @@ func evalTypeRepresentationFromJSONPath(httpSchema *rest.NDCHttpSchema, jsonPath
 		return nil, err
 	}
 
+	if typeRep == nil {
+		return nil, nil
+	}
+
 	// if the json path selects the root field only, remove the argument field
 	if len(segments) == 1 && isGlobal {
 		delete(operation.Arguments, rootSelector)
@@ -113,6 +117,10 @@ func evalArgumentFromJSONPath(httpSchema *rest.NDCHttpSchema, typeSchema schema.
 		underlyingType, typeRep, err := evalArgumentFromJSONPath(httpSchema, t.UnderlyingType, segments, fieldPaths)
 		if err != nil {
 			return nil, nil, err
+		}
+
+		if underlyingType == nil {
+			return nil, nil, nil
 		}
 
 		if _, ok := underlyingType.(*schema.NullableType); ok {

--- a/ndc-http-schema/configuration/schema.go
+++ b/ndc-http-schema/configuration/schema.go
@@ -101,32 +101,6 @@ func MergeNDCHttpSchemas(config *Configuration, schemas []NDCHttpRuntimeSchema) 
 		settings := item.Settings
 		if settings == nil {
 			settings = &rest.NDCHttpSettings{}
-		} else {
-			for i, server := range settings.Servers {
-				if server.Security.IsEmpty() {
-					server.Security = settings.Security
-				}
-				if server.SecuritySchemes == nil {
-					server.SecuritySchemes = make(map[string]rest.SecurityScheme)
-				}
-				for key, scheme := range settings.SecuritySchemes {
-					_, ok := server.SecuritySchemes[key]
-					if !ok {
-						server.SecuritySchemes[key] = scheme
-					}
-				}
-
-				if server.Headers == nil {
-					server.Headers = make(map[string]utils.EnvString)
-				}
-				for key, value := range settings.Headers {
-					_, ok := server.Headers[key]
-					if !ok {
-						server.Headers[key] = value
-					}
-				}
-				settings.Servers[i] = server
-			}
 		}
 
 		meta := NDCHttpRuntimeSchema{

--- a/ndc-http-schema/configuration/update.go
+++ b/ndc-http-schema/configuration/update.go
@@ -38,6 +38,12 @@ func UpdateHTTPConfiguration(configurationDir string, logger *slog.Logger) (*Con
 
 	// cache the output file to disk
 	if config.Output != "" {
+		// remove jsonschema reference inside schemas
+		for i, s := range schemas {
+			s.SchemaRef = ""
+			schemas[i] = s
+		}
+
 		if err := utils.WriteSchemaFile(filepath.Join(configurationDir, config.Output), schemas); err != nil {
 			return nil, nil, nil, err
 		}

--- a/ndc-http-schema/configuration/validate.go
+++ b/ndc-http-schema/configuration/validate.go
@@ -174,7 +174,7 @@ func (cv *ConfigValidator) evaluateSchema(ndcSchema *NDCHttpRuntimeSchema) error
 		cv.validateTLS(ndcSchema.Name, "settings.tls", ndcSchema.Settings.TLS)
 	}
 
-	cv.validateArgumentPresets(ndcSchema.Name, "settings.argumentPresets", ndcSchema.Settings.ArgumentPresets)
+	cv.validateArgumentPresets(ndcSchema.Name, "settings.argumentPresets", ndcSchema.Settings.ArgumentPresets, true)
 
 	for i, server := range ndcSchema.Settings.Servers {
 		serverPath := fmt.Sprintf("settings.server[%d]", i)
@@ -207,15 +207,15 @@ func (cv *ConfigValidator) evaluateSchema(ndcSchema *NDCHttpRuntimeSchema) error
 			cv.validateTLS(ndcSchema.Name, serverPath+".tls", server.TLS)
 		}
 
-		cv.validateArgumentPresets(ndcSchema.Name, serverPath+".argumentPresets", server.ArgumentPresets)
+		cv.validateArgumentPresets(ndcSchema.Name, serverPath+".argumentPresets", server.ArgumentPresets, false)
 	}
 
 	return nil
 }
 
-func (cv *ConfigValidator) validateArgumentPresets(namespace string, key string, argumentPresets []schema.ArgumentPresetConfig) {
+func (cv *ConfigValidator) validateArgumentPresets(namespace string, key string, argumentPresets []schema.ArgumentPresetConfig, isGlobal bool) {
 	for i, preset := range argumentPresets {
-		_, _, err := ValidateArgumentPreset(cv.mergedSchema, preset)
+		_, _, err := ValidateArgumentPreset(cv.mergedSchema, preset, isGlobal)
 		if err != nil {
 			cv.addError(namespace, fmt.Sprintf("%s[%d]: %s", key, i, err))
 

--- a/ndc-http-schema/openapi/internal/types.go
+++ b/ndc-http-schema/openapi/internal/types.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	bracketRegexp         = regexp.MustCompile(`[\{\}]`)
+	oasVariableRegex      = regexp.MustCompile(`^\{([a-zA-Z0-9_-]+)\}$`)
 	schemaRefNameV2Regexp = regexp.MustCompile(`^#/definitions/(.+)$`)
 	schemaRefNameV3Regexp = regexp.MustCompile(`^#/components/schemas/(.+)$`)
 )

--- a/ndc-http-schema/openapi/oas3_test.go
+++ b/ndc-http-schema/openapi/oas3_test.go
@@ -4,11 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
-	"reflect"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hasura/ndc-http/ndc-http-schema/schema"
 	"gotest.tools/v3/assert"
 )
@@ -129,9 +126,5 @@ func assertRESTSchemaEqual(t *testing.T, expected *schema.NDCHttpSchema, output 
 
 func assertDeepEqual(t *testing.T, expected any, reality any) {
 	t.Helper()
-	assert.DeepEqual(t,
-		expected, reality,
-		cmpopts.IgnoreUnexported(schema.ServerConfig{}, schema.NDCHttpSettings{}),
-		cmp.Exporter(func(t reflect.Type) bool { return true }),
-	)
+	assert.DeepEqual(t, expected, reality)
 }

--- a/ndc-http-schema/openapi/testdata/onesignal/expected-patch.json
+++ b/ndc-http-schema/openapi/testdata/onesignal/expected-patch.json
@@ -30,7 +30,6 @@
     },
     "version": "1.2.2"
   },
-  "collections": [],
   "procedures": {
     "create_notification": {
       "request": {
@@ -64,7 +63,6 @@
         }
       },
       "description": "Create notification",
-      "name": "create_notification",
       "result_type": {
         "name": "CreateNotificationSuccessResponse",
         "type": "named"
@@ -128,9 +126,52 @@
         }
       },
       "description": "Stop a scheduled or currently outgoing notification",
-      "name": "cancel_notification",
       "result_type": {
         "name": "CancelNotificationSuccessResponse",
+        "type": "named"
+      }
+    },
+    "export_events": {
+      "request": {
+        "url": "/notifications/{notification_id}/export_events",
+        "method": "post",
+        "response": {
+          "contentType": "application/json"
+        }
+      },
+      "arguments": {
+        "app_id": {
+          "description": "The ID of the app that the notification belongs to.",
+          "type": {
+            "name": "String",
+            "type": "named"
+          },
+          "http": {
+            "name": "app_id",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        },
+        "notification_id": {
+          "description": "The ID of the notification to export events from.",
+          "type": {
+            "name": "String",
+            "type": "named"
+          },
+          "http": {
+            "name": "notification_id",
+            "in": "path",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        }
+      },
+      "description": "Export CSV of Events",
+      "result_type": {
+        "name": "ExportEventsSuccessResponse",
         "type": "named"
       }
     }
@@ -146,8 +187,8 @@
       "comparison_operators": {},
       "representation": {
         "one_of": [
-          "\u003e",
-          "\u003c",
+          ">",
+          "<",
           "=",
           "!=",
           "exists",

--- a/ndc-http-schema/openapi/testdata/onesignal/expected.json
+++ b/ndc-http-schema/openapi/testdata/onesignal/expected.json
@@ -332,6 +332,24 @@
         }
       }
     },
+    "ExportEventsSuccessResponse": {
+      "fields": {
+        "csv_file_url": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        }
+      }
+    },
     "Filter": {
       "fields": {
         "field": {
@@ -1234,6 +1252,54 @@
         "type": "named"
       }
     },
+    "export_events": {
+      "request": {
+        "url": "/notifications/{notification_id}/export_events",
+        "method": "post",
+        "response": {
+          "contentType": "application/json"
+        }
+      },
+      "arguments": {
+        "app_id": {
+          "description": "The ID of the app that the notification belongs to.",
+          "type": {
+            "name": "String",
+            "type": "named"
+          },
+          "http": {
+            "name": "app_id",
+            "in": "query",
+            "schema": {
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
+        "notification_id": {
+          "description": "The ID of the notification to export events from.",
+          "type": {
+            "name": "String",
+            "type": "named"
+          },
+          "http": {
+            "name": "notification_id",
+            "in": "path",
+            "schema": {
+              "type": [
+                "string"
+              ]
+            }
+          }
+        }
+      },
+      "description": "Export CSV of Events",
+      "result_type": {
+        "name": "ExportEventsSuccessResponse",
+        "type": "named"
+      }
+    },
     "get_notification_history": {
       "request": {
         "url": "/notifications/{notification_id}/history",
@@ -1298,8 +1364,8 @@
       "comparison_operators": {},
       "representation": {
         "one_of": [
-          "\u003e",
-          "\u003c",
+          ">",
+          "<",
           "=",
           "!=",
           "exists",

--- a/ndc-http-schema/openapi/testdata/onesignal/schema.json
+++ b/ndc-http-schema/openapi/testdata/onesignal/schema.json
@@ -179,6 +179,19 @@
         }
       }
     },
+    "ExportEventsSuccessResponse": {
+      "fields": {
+        "csv_file_url": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        }
+      }
+    },
     "Filter": {
       "fields": {
         "field": {
@@ -758,6 +771,30 @@
     },
     {
       "arguments": {
+        "app_id": {
+          "description": "The ID of the app that the notification belongs to.",
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        },
+        "notification_id": {
+          "description": "The ID of the notification to export events from.",
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        }
+      },
+      "description": "Export CSV of Events",
+      "name": "export_events",
+      "result_type": {
+        "name": "ExportEventsSuccessResponse",
+        "type": "named"
+      }
+    },
+    {
+      "arguments": {
         "body": {
           "description": "Request body of POST /notifications/{notification_id}/history",
           "type": {
@@ -794,8 +831,8 @@
       "comparison_operators": {},
       "representation": {
         "one_of": [
-          "\u003e",
-          "\u003c",
+          ">",
+          "<",
           "=",
           "!=",
           "exists",

--- a/ndc-http-schema/openapi/testdata/onesignal/source.json
+++ b/ndc-http-schema/openapi/testdata/onesignal/source.json
@@ -603,6 +603,14 @@
             }
           }
         }
+      },
+      "ExportEventsSuccessResponse": {
+        "type": "object",
+        "properties": {
+          "csv_file_url": {
+            "type": "string"
+          }
+        }
       }
     }
   },
@@ -943,6 +951,45 @@
             "app_key": []
           }
         ]
+      }
+    },
+    "/notifications/{notification_id}/export_events?app_id={app_id}": {
+      "post": {
+        "operationId": "export_events",
+        "summary": "Export CSV of Events",
+        "description": "Generate a compressed CSV report of all of the events data for a notification.\nThis will return a URL immediately upon success but it may take several minutes for the CSV to become available at that URL depending on the volume of data. Only one export can be in-progress per OneSignal account at any given time.",
+        "parameters": [
+          {
+            "name": "notification_id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the notification to export events from.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "app_id",
+            "in": "query",
+            "required": true,
+            "description": "The ID of the app that the notification belongs to.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExportEventsSuccessResponse"
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/ndc-http-schema/openapi/testdata/petstore2/expected.json
+++ b/ndc-http-schema/openapi/testdata/petstore2/expected.json
@@ -592,8 +592,11 @@
       },
       "description": "Explore details about a given subject node",
       "result_type": {
-        "name": "JSON",
-        "type": "named"
+        "type": "nullable",
+        "underlying_type": {
+          "name": "JSON",
+          "type": "named"
+        }
       }
     },
     "listOAuth2Clients": {
@@ -2359,7 +2362,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -2410,7 +2413,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -2471,7 +2474,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -2506,7 +2509,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -2624,7 +2627,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -2672,7 +2675,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -2733,7 +2736,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -2789,7 +2792,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }

--- a/ndc-http-schema/openapi/testdata/petstore2/schema.json
+++ b/ndc-http-schema/openapi/testdata/petstore2/schema.json
@@ -273,8 +273,11 @@
       "description": "Explore details about a given subject node",
       "name": "get_subject",
       "result_type": {
-        "name": "JSON",
-        "type": "named"
+        "type": "nullable",
+        "underlying_type": {
+          "name": "JSON",
+          "type": "named"
+        }
       }
     },
     {
@@ -1350,7 +1353,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -1379,7 +1382,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -1408,7 +1411,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -1428,7 +1431,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -1481,7 +1484,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -1501,7 +1504,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -1528,7 +1531,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -1555,7 +1558,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }

--- a/ndc-http-schema/openapi/testdata/petstore3/expected.json
+++ b/ndc-http-schema/openapi/testdata/petstore3/expected.json
@@ -612,7 +612,7 @@
           }
         },
         "return": {
-          "description": "XPath expression that defines which values will be returned.  Instead of returning a collection of projects or packages, the result will be a collection of:   - contents of elements, when that XPath expression match elements, or,   - values of atttributes, when that XPath expression match atttributes.  Example of result, for a query string like `?in=projects\u0026match=repository/arch='x86_64'\u0026return=repository/name`: ```    openSUSE_Tumbleweed   15.3  ```",
+          "description": "XPath expression that defines which values will be returned.  Instead of returning a collection of projects or packages, the result will be a collection of:   - contents of elements, when that XPath expression match elements, or,   - values of atttributes, when that XPath expression match atttributes.  Example of result, for a query string like `?in=projects&match=repository/arch='x86_64'&return=repository/name`: ```    openSUSE_Tumbleweed   15.3  ```",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -631,7 +631,7 @@
           }
         },
         "values": {
-          "description": "When set to `1`, return a list of values, instead of returning a list of projects or packages.  The result will be a collection of:   - contents of elements, when the expression defined in the `match` query parameter match elements.     For example: `match=repository/arch`.   - values of atttributes, when the expression defined in the `match` query parameter match atttributes.     For example: `match=repository/name`.  Example of result, for a query string like `?in=projects\u0026match=repository/path/project\u0026values=1`: ```    openSUSE.org:openSUSE:Factory   openSUSE.org:openSUSE:Leap:15.3  ```",
+          "description": "When set to `1`, return a list of values, instead of returning a list of projects or packages.  The result will be a collection of:   - contents of elements, when the expression defined in the `match` query parameter match elements.     For example: `match=repository/arch`.   - values of atttributes, when the expression defined in the `match` query parameter match atttributes.     For example: `match=repository/name`.  Example of result, for a query string like `?in=projects&match=repository/path/project&values=1`: ```    openSUSE.org:openSUSE:Factory   openSUSE.org:openSUSE:Leap:15.3  ```",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -7849,7 +7849,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -7911,7 +7911,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -7946,7 +7946,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -8198,7 +8198,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }

--- a/ndc-http-schema/openapi/testdata/petstore3/expected.json
+++ b/ndc-http-schema/openapi/testdata/petstore3/expected.json
@@ -872,6 +872,99 @@
         "name": "##default"
       }
     },
+    "BillingMeterEvent": {
+      "description": "Meter events represent actions that customers take in your system. You can use meter events to bill a customer based on their usage. Meter events are associated with billing meters, which define both the contents of the events payload and how to aggregate those events.",
+      "fields": {
+        "created": {
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
+          "type": {
+            "name": "UnixTime",
+            "type": "named"
+          },
+          "http": {
+            "type": [
+              "integer"
+            ],
+            "format": "unix-time"
+          }
+        },
+        "event_name": {
+          "description": "The name of the meter event. Corresponds with the `event_name` field on a meter.",
+          "type": {
+            "name": "String",
+            "type": "named"
+          },
+          "http": {
+            "type": [
+              "string"
+            ],
+            "maxLength": 100
+          }
+        },
+        "identifier": {
+          "description": "A unique identifier for the event.",
+          "type": {
+            "name": "String",
+            "type": "named"
+          },
+          "http": {
+            "type": [
+              "string"
+            ],
+            "maxLength": 5000
+          }
+        },
+        "livemode": {
+          "description": "Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.",
+          "type": {
+            "name": "Boolean",
+            "type": "named"
+          },
+          "http": {
+            "type": [
+              "boolean"
+            ]
+          }
+        },
+        "object": {
+          "description": "String representing the object's type. Objects of the same type share the same value.",
+          "type": {
+            "name": "BillingMeterEventObject",
+            "type": "named"
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "payload": {
+          "description": "The payload of the event. This contains the fields corresponding to a meter's `customer_mapping.event_payload_key` (default is `stripe_customer_id`) and `value_settings.event_payload_key` (default is `value`). Read more about the [payload](https://stripe.com/docs/billing/subscriptions/usage-based/recording-usage#payload-key-overrides).",
+          "type": {
+            "name": "JSON",
+            "type": "named"
+          },
+          "http": {
+            "type": [
+              "object"
+            ]
+          }
+        },
+        "timestamp": {
+          "description": "The timestamp passed in when creating the event. Measured in seconds since the Unix epoch.",
+          "type": {
+            "name": "UnixTime",
+            "type": "named"
+          },
+          "http": {
+            "type": [
+              "integer"
+            ],
+            "format": "unix-time"
+          }
+        }
+      }
+    },
     "Book": {
       "fields": {
         "attr": {
@@ -1455,6 +1548,91 @@
       },
       "xml": {
         "name": "pet"
+      }
+    },
+    "PostBillingMeterEventsBody": {
+      "fields": {
+        "event_name": {
+          "description": "The name of the meter event. Corresponds with the `event_name` field on a meter.",
+          "type": {
+            "name": "String",
+            "type": "named"
+          },
+          "http": {
+            "type": [
+              "string"
+            ],
+            "maxLength": 100
+          }
+        },
+        "expand": {
+          "description": "Specifies which fields in the response should be expanded.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "String",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          },
+          "http": {
+            "type": [
+              "array"
+            ],
+            "items": {
+              "type": [
+                "string"
+              ],
+              "maxLength": 5000
+            }
+          }
+        },
+        "identifier": {
+          "description": "A unique identifier for the event. If not provided, one is generated. We recommend using UUID-like identifiers. We will enforce uniqueness within a rolling period of at least 24 hours. The enforcement of uniqueness primarily addresses issues arising from accidental retries or other problems occurring within extremely brief time intervals. This approach helps prevent duplicate entries and ensures data integrity in high-frequency operations.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ],
+            "maxLength": 100
+          }
+        },
+        "payload": {
+          "description": "The payload of the event. This must contain the fields corresponding to a meter's `customer_mapping.event_payload_key` (default is `stripe_customer_id`) and `value_settings.event_payload_key` (default is `value`). Read more about the [payload](https://docs.stripe.com/billing/subscriptions/usage-based/recording-usage#payload-key-overrides).",
+          "type": {
+            "name": "JSON",
+            "type": "named"
+          },
+          "http": {
+            "type": [
+              "object"
+            ]
+          }
+        },
+        "timestamp": {
+          "description": "The time of the event. Measured in seconds since the Unix epoch. Must be within the past 35 calendar days or up to 5 minutes in the future. Defaults to current timestamp if not specified.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "UnixTime",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "integer"
+            ],
+            "format": "unix-time"
+          }
+        }
       }
     },
     "PostCheckoutSessionsBody": {
@@ -7232,6 +7410,45 @@
         "type": "named"
       }
     },
+    "PostBillingMeterEvents": {
+      "request": {
+        "url": "/v1/billing/meter_events",
+        "method": "post",
+        "requestBody": {
+          "contentType": "application/x-www-form-urlencoded",
+          "encoding": {
+            "expand": {
+              "style": "deepObject",
+              "explode": true
+            },
+            "payload": {
+              "style": "deepObject",
+              "explode": true
+            }
+          }
+        },
+        "response": {
+          "contentType": "application/json"
+        }
+      },
+      "arguments": {
+        "body": {
+          "description": "Request body of POST /v1/billing/meter_events",
+          "type": {
+            "name": "PostBillingMeterEventsBody",
+            "type": "named"
+          },
+          "http": {
+            "in": "body"
+          }
+        }
+      },
+      "description": "Create a billing meter event",
+      "result_type": {
+        "name": "BillingMeterEvent",
+        "type": "named"
+      }
+    },
     "PostCheckoutSessions": {
       "request": {
         "url": "/v1/checkout/sessions",
@@ -7353,7 +7570,7 @@
         "servers": [
           {
             "url": {
-              "value": "https://files.stripe.com/",
+              "value": "https://files.stripe.com",
               "env": "PET_STORE_SERVER_URL"
             }
           }
@@ -8131,6 +8348,16 @@
     }
   },
   "scalar_types": {
+    "BillingMeterEventObject": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "billing.meter_event"
+        ],
+        "type": "enum"
+      }
+    },
     "Binary": {
       "aggregate_functions": {},
       "comparison_operators": {},

--- a/ndc-http-schema/openapi/testdata/petstore3/schema.json
+++ b/ndc-http-schema/openapi/testdata/petstore3/schema.json
@@ -265,7 +265,7 @@
           }
         },
         "return": {
-          "description": "XPath expression that defines which values will be returned.  Instead of returning a collection of projects or packages, the result will be a collection of:   - contents of elements, when that XPath expression match elements, or,   - values of atttributes, when that XPath expression match atttributes.  Example of result, for a query string like `?in=projects\u0026match=repository/arch='x86_64'\u0026return=repository/name`: ```    openSUSE_Tumbleweed   15.3  ```",
+          "description": "XPath expression that defines which values will be returned.  Instead of returning a collection of projects or packages, the result will be a collection of:   - contents of elements, when that XPath expression match elements, or,   - values of atttributes, when that XPath expression match atttributes.  Example of result, for a query string like `?in=projects&match=repository/arch='x86_64'&return=repository/name`: ```    openSUSE_Tumbleweed   15.3  ```",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -275,7 +275,7 @@
           }
         },
         "values": {
-          "description": "When set to `1`, return a list of values, instead of returning a list of projects or packages.  The result will be a collection of:   - contents of elements, when the expression defined in the `match` query parameter match elements.     For example: `match=repository/arch`.   - values of atttributes, when the expression defined in the `match` query parameter match atttributes.     For example: `match=repository/name`.  Example of result, for a query string like `?in=projects\u0026match=repository/path/project\u0026values=1`: ```    openSUSE.org:openSUSE:Factory   openSUSE.org:openSUSE:Leap:15.3  ```",
+          "description": "When set to `1`, return a list of values, instead of returning a list of projects or packages.  The result will be a collection of:   - contents of elements, when the expression defined in the `match` query parameter match elements.     For example: `match=repository/arch`.   - values of atttributes, when the expression defined in the `match` query parameter match atttributes.     For example: `match=repository/name`.  Example of result, for a query string like `?in=projects&match=repository/path/project&values=1`: ```    openSUSE.org:openSUSE:Factory   openSUSE.org:openSUSE:Leap:15.3  ```",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -4681,7 +4681,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -4710,7 +4710,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -4730,7 +4730,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }
@@ -4864,7 +4864,7 @@
       "result_type": {
         "type": "nullable",
         "underlying_type": {
-          "name": "Boolean",
+          "name": "JSON",
           "type": "named"
         }
       }

--- a/ndc-http-schema/openapi/testdata/petstore3/schema.json
+++ b/ndc-http-schema/openapi/testdata/petstore3/schema.json
@@ -421,6 +421,60 @@
         }
       }
     },
+    "BillingMeterEvent": {
+      "description": "Meter events represent actions that customers take in your system. You can use meter events to bill a customer based on their usage. Meter events are associated with billing meters, which define both the contents of the events payload and how to aggregate those events.",
+      "fields": {
+        "created": {
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
+          "type": {
+            "name": "UnixTime",
+            "type": "named"
+          }
+        },
+        "event_name": {
+          "description": "The name of the meter event. Corresponds with the `event_name` field on a meter.",
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        },
+        "identifier": {
+          "description": "A unique identifier for the event.",
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        },
+        "livemode": {
+          "description": "Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.",
+          "type": {
+            "name": "Boolean",
+            "type": "named"
+          }
+        },
+        "object": {
+          "description": "String representing the object's type. Objects of the same type share the same value.",
+          "type": {
+            "name": "BillingMeterEventObject",
+            "type": "named"
+          }
+        },
+        "payload": {
+          "description": "The payload of the event. This contains the fields corresponding to a meter's `customer_mapping.event_payload_key` (default is `stripe_customer_id`) and `value_settings.event_payload_key` (default is `value`). Read more about the [payload](https://stripe.com/docs/billing/subscriptions/usage-based/recording-usage#payload-key-overrides).",
+          "type": {
+            "name": "JSON",
+            "type": "named"
+          }
+        },
+        "timestamp": {
+          "description": "The timestamp passed in when creating the event. Measured in seconds since the Unix epoch.",
+          "type": {
+            "name": "UnixTime",
+            "type": "named"
+          }
+        }
+      }
+    },
     "Book": {
       "fields": {
         "attr": {
@@ -752,6 +806,57 @@
                 "type": "named"
               },
               "type": "array"
+            }
+          }
+        }
+      }
+    },
+    "PostBillingMeterEventsBody": {
+      "fields": {
+        "event_name": {
+          "description": "The name of the meter event. Corresponds with the `event_name` field on a meter.",
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        },
+        "expand": {
+          "description": "Specifies which fields in the response should be expanded.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "String",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "identifier": {
+          "description": "A unique identifier for the event. If not provided, one is generated. We recommend using UUID-like identifiers. We will enforce uniqueness within a rolling period of at least 24 hours. The enforcement of uniqueness primarily addresses issues arising from accidental retries or other problems occurring within extremely brief time intervals. This approach helps prevent duplicate entries and ensures data integrity in high-frequency operations.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
+        "payload": {
+          "description": "The payload of the event. This must contain the fields corresponding to a meter's `customer_mapping.event_payload_key` (default is `stripe_customer_id`) and `value_settings.event_payload_key` (default is `value`). Read more about the [payload](https://docs.stripe.com/billing/subscriptions/usage-based/recording-usage#payload-key-overrides).",
+          "type": {
+            "name": "JSON",
+            "type": "named"
+          }
+        },
+        "timestamp": {
+          "description": "The time of the event. Measured in seconds since the Unix epoch. Must be within the past 35 calendar days or up to 5 minutes in the future. Defaults to current timestamp if not specified.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "UnixTime",
+              "type": "named"
             }
           }
         }
@@ -4412,6 +4517,23 @@
     {
       "arguments": {
         "body": {
+          "description": "Request body of POST /v1/billing/meter_events",
+          "type": {
+            "name": "PostBillingMeterEventsBody",
+            "type": "named"
+          }
+        }
+      },
+      "description": "Create a billing meter event",
+      "name": "PostBillingMeterEvents",
+      "result_type": {
+        "name": "BillingMeterEvent",
+        "type": "named"
+      }
+    },
+    {
+      "arguments": {
+        "body": {
           "description": "Request body of POST /v1/checkout/sessions",
           "type": {
             "type": "nullable",
@@ -4813,6 +4935,16 @@
     }
   ],
   "scalar_types": {
+    "BillingMeterEventObject": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "billing.meter_event"
+        ],
+        "type": "enum"
+      }
+    },
     "Binary": {
       "aggregate_functions": {},
       "comparison_operators": {},

--- a/ndc-http-schema/openapi/testdata/petstore3/source.json
+++ b/ndc-http-schema/openapi/testdata/petstore3/source.json
@@ -3677,6 +3677,89 @@
           }
         }
       }
+    },
+    "/v1/billing/meter_events": {
+      "post": {
+        "description": "<p>Creates a billing meter event.</p>",
+        "operationId": "PostBillingMeterEvents",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "encoding": {
+                "expand": {
+                  "explode": true,
+                  "style": "deepObject"
+                },
+                "payload": {
+                  "explode": true,
+                  "style": "deepObject"
+                }
+              },
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "event_name": {
+                    "description": "The name of the meter event. Corresponds with the `event_name` field on a meter.",
+                    "maxLength": 100,
+                    "type": "string"
+                  },
+                  "expand": {
+                    "description": "Specifies which fields in the response should be expanded.",
+                    "items": {
+                      "maxLength": 5000,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "identifier": {
+                    "description": "A unique identifier for the event. If not provided, one is generated. We recommend using UUID-like identifiers. We will enforce uniqueness within a rolling period of at least 24 hours. The enforcement of uniqueness primarily addresses issues arising from accidental retries or other problems occurring within extremely brief time intervals. This approach helps prevent duplicate entries and ensures data integrity in high-frequency operations.",
+                    "maxLength": 100,
+                    "type": "string"
+                  },
+                  "payload": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "The payload of the event. This must contain the fields corresponding to a meter's `customer_mapping.event_payload_key` (default is `stripe_customer_id`) and `value_settings.event_payload_key` (default is `value`). Read more about the [payload](https://docs.stripe.com/billing/subscriptions/usage-based/recording-usage#payload-key-overrides).",
+                    "type": "object"
+                  },
+                  "timestamp": {
+                    "description": "The time of the event. Measured in seconds since the Unix epoch. Must be within the past 35 calendar days or up to 5 minutes in the future. Defaults to current timestamp if not specified.",
+                    "format": "unix-time",
+                    "type": "integer"
+                  }
+                },
+                "required": ["event_name", "payload"],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/billing.meter_event"
+                }
+              }
+            },
+            "description": "Successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Error response."
+          }
+        },
+        "summary": "Create a billing meter event"
+      }
     }
   },
   "components": {
@@ -4198,6 +4281,61 @@
           "prefix": "smp",
           "namespace": "http://example.com/schema"
         }
+      },
+      "billing.meter_event": {
+        "description": "Meter events represent actions that customers take in your system. You can use meter events to bill a customer based on their usage. Meter events are associated with billing meters, which define both the contents of the event’s payload and how to aggregate those events.",
+        "properties": {
+          "created": {
+            "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
+            "format": "unix-time",
+            "type": "integer"
+          },
+          "event_name": {
+            "description": "The name of the meter event. Corresponds with the `event_name` field on a meter.",
+            "maxLength": 100,
+            "type": "string"
+          },
+          "identifier": {
+            "description": "A unique identifier for the event.",
+            "maxLength": 5000,
+            "type": "string"
+          },
+          "livemode": {
+            "description": "Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.",
+            "type": "boolean"
+          },
+          "object": {
+            "description": "String representing the object's type. Objects of the same type share the same value.",
+            "enum": ["billing.meter_event"],
+            "type": "string"
+          },
+          "payload": {
+            "additionalProperties": {
+              "maxLength": 100,
+              "type": "string"
+            },
+            "description": "The payload of the event. This contains the fields corresponding to a meter's `customer_mapping.event_payload_key` (default is `stripe_customer_id`) and `value_settings.event_payload_key` (default is `value`). Read more about the [payload](https://stripe.com/docs/billing/subscriptions/usage-based/recording-usage#payload-key-overrides).",
+            "type": "object"
+          },
+          "timestamp": {
+            "description": "The timestamp passed in when creating the event. Measured in seconds since the Unix epoch.",
+            "format": "unix-time",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "created",
+          "event_name",
+          "identifier",
+          "livemode",
+          "object",
+          "payload",
+          "timestamp"
+        ],
+        "title": "BillingMeterEvent",
+        "type": "object",
+        "x-expandableFields": [],
+        "x-resourceId": "billing.meter_event"
       }
     },
     "requestBodies": {

--- a/ndc-http-schema/utils/file.go
+++ b/ndc-http-schema/utils/file.go
@@ -26,6 +26,7 @@ func MarshalSchema(content any, format schema.SchemaFileFormat) ([]byte, error) 
 	case schema.SchemaFileJSON:
 		encoder := json.NewEncoder(&fileBuffer)
 		encoder.SetIndent("", "  ")
+		encoder.SetEscapeHTML(false)
 
 		if err := encoder.Encode(content); err != nil {
 			return nil, fmt.Errorf("failed to encode NDC HTTP schema: %w", err)

--- a/ndc-http-schema/utils/string.go
+++ b/ndc-http-schema/utils/string.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -218,6 +219,9 @@ func RemoveYAMLSpecialCharacters(input []byte) string {
 				u := getu4(input[i:])
 				if u > -1 {
 					i += 5
+					if slices.Contains([]rune{'<', '>', '&'}, u) {
+						sb.WriteRune(u)
+					}
 				} else {
 					sb.WriteRune(r)
 					i++


### PR DESCRIPTION
- Fix incorrectly encoding Arbitrary JSON scalar for `application/x-www-form-urlencoded` content type.
- Fix argument preset initialization in server settings.
- Disable HTML escape when encoding JSON.
- Reroute HTTP 4xx response from the remote request to HTTP 422 so the detail can appear in the graphql error. 
- Use JSON  for the result type if the response is unknown.