### PR TITLE
Improve unknown content type parser and separate oneOf body to multiple operations

### DIFF
--- a/connector/internal/argument/preset.go
+++ b/connector/internal/argument/preset.go
@@ -3,7 +3,6 @@ package argument
 import (
 	"errors"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 
@@ -124,7 +123,6 @@ func (ap ArgumentPreset) evalNestedField(segments []*spec.Segment, argument any,
 			return argument, nil
 		}
 
-		log.Println(selector, argumentSlice)
 		step := selector.Step()
 		if step < 1 {
 			step = 1

--- a/connector/internal/contenttype/json.go
+++ b/connector/internal/contenttype/json.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	rest "github.com/hasura/ndc-http/ndc-http-schema/schema"
+	restUtils "github.com/hasura/ndc-http/ndc-http-schema/utils"
 	"github.com/hasura/ndc-sdk-go/schema"
 	"github.com/hasura/ndc-sdk-go/utils"
 )
@@ -27,7 +28,7 @@ func NewJSONDecoder(httpSchema *rest.NDCHttpSchema) *JSONDecoder {
 
 // Decode unmarshals json and evaluate the schema type.
 func (c *JSONDecoder) Decode(r io.Reader, resultType schema.Type) (any, error) {
-	underlyingType, _, err := UnwrapNullableType(resultType)
+	underlyingType, _, err := restUtils.UnwrapNullableType(resultType)
 	if err != nil {
 		return nil, err
 	}

--- a/connector/internal/contenttype/utils.go
+++ b/connector/internal/contenttype/utils.go
@@ -7,8 +7,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-
-	"github.com/hasura/ndc-sdk-go/schema"
 )
 
 var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
@@ -49,22 +47,5 @@ func StringifySimpleScalar(val reflect.Value, kind reflect.Kind) (string, error)
 		}
 
 		return string(j), nil
-	}
-}
-
-// UnwrapNullableType unwraps the underlying type of the nullable type
-func UnwrapNullableType(input schema.Type) (schema.TypeEncoder, bool, error) {
-	switch ty := input.Interface().(type) {
-	case *schema.NullableType:
-		childType, _, err := UnwrapNullableType(ty.UnderlyingType)
-		if err != nil {
-			return nil, false, err
-		}
-
-		return childType, true, nil
-	case *schema.NamedType, *schema.ArrayType:
-		return ty, false, nil
-	default:
-		return nil, false, fmt.Errorf("invalid type %v", input)
 	}
 }

--- a/connector/internal/request_builder.go
+++ b/connector/internal/request_builder.go
@@ -181,7 +181,7 @@ func (c *RequestBuilder) getRequestUploadBody(rawRequest *rest.Request, bodyInfo
 		return rawRequest.RequestBody
 	}
 
-	bi, ok, err := contenttype.UnwrapNullableType(bodyInfo.Type)
+	bi, ok, err := restUtils.UnwrapNullableType(bodyInfo.Type)
 	if err != nil || !ok {
 		return nil
 	}

--- a/connector/mutation.go
+++ b/connector/mutation.go
@@ -113,7 +113,9 @@ func (c *HTTPConnector) execMutationOperation(parentCtx context.Context, state *
 	var err error
 	if operation.Name == internal.ProcedureSendHTTPRequest {
 		requests, err = internal.NewRawRequestBuilder(operation, c.config.ForwardHeaders).Build()
-		requests.Operation = &c.procSendHttpRequest
+		if err == nil {
+			requests.Operation = &c.procSendHttpRequest
+		}
 	} else {
 		requests, err = c.explainProcedure(&operation)
 	}

--- a/docs/argument_presets.md
+++ b/docs/argument_presets.md
@@ -40,13 +40,21 @@ You can use argument presets to set default values to request arguments. Argumen
           "value": 1
         },
         "targets": ["addPet"]
+      },
+      {
+        "path": "body.categories[*].id",
+        "value": {
+          "type": "literal",
+          "value": 1
+        },
+        "targets": []
       }
     ]
   }
 }
 ```
 
-The target argument field is removed from the `arguments` schema if the selector is the root field. If the path selects the nested field the target field becomes nullable.
+The target argument field is removed from the `arguments` schema if the selector is the root field. If the path selects the nested field the target field becomes nullable. Support object properties and array selectors.
 
 ## Configuration options
 

--- a/ndc-http-schema/command/convert.go
+++ b/ndc-http-schema/command/convert.go
@@ -61,7 +61,6 @@ func CommandConvertToNDCSchema(args *configuration.ConvertCommandArguments, logg
 		slog.Any("patch_before", config.PatchBefore),
 		slog.Any("patch_after", config.PatchAfter),
 		slog.Any("allowed_content_types", config.AllowedContentTypes),
-		slog.Bool("strict", config.Strict),
 		slog.Bool("pure", config.Pure),
 		slog.Bool("no_deprecation", config.NoDeprecation),
 	)

--- a/ndc-http-schema/configuration/convert.go
+++ b/ndc-http-schema/configuration/convert.go
@@ -31,7 +31,6 @@ func ConvertToNDCSchema(config *ConvertConfig, logger *slog.Logger) (*schema.NDC
 		TrimPrefix:          config.TrimPrefix,
 		EnvPrefix:           config.EnvPrefix,
 		AllowedContentTypes: config.AllowedContentTypes,
-		Strict:              config.Strict,
 		NoDeprecation:       config.NoDeprecation,
 		Logger:              logger,
 	}
@@ -79,9 +78,7 @@ func ResolveConvertConfigArguments(config *ConvertConfig, configDir string, args
 		if args.Pure {
 			config.Pure = args.Pure
 		}
-		if args.Strict {
-			config.Strict = args.Strict
-		}
+
 		if args.NoDeprecation {
 			config.NoDeprecation = args.NoDeprecation
 		}

--- a/ndc-http-schema/configuration/types.go
+++ b/ndc-http-schema/configuration/types.go
@@ -23,10 +23,10 @@ var fieldNameRegex = regexp.MustCompile(`^[a-zA-Z_]\w+$`)
 type Configuration struct {
 	Output string `json:"output,omitempty" yaml:"output,omitempty"`
 	// Require strict validation
-	Strict         bool                   `json:"strict"         yaml:"strict"`
-	ForwardHeaders ForwardHeadersSettings `json:"forwardHeaders" yaml:"forwardHeaders"`
-	Concurrency    ConcurrencySettings    `json:"concurrency"    yaml:"concurrency"`
-	Files          []ConfigItem           `json:"files"          yaml:"files"`
+	Strict         bool                   `json:"strict"                   yaml:"strict"`
+	ForwardHeaders ForwardHeadersSettings `json:"forwardHeaders,omitempty" yaml:"forwardHeaders,omitempty"`
+	Concurrency    ConcurrencySettings    `json:"concurrency,omitempty"    yaml:"concurrency,omitempty"`
+	Files          []ConfigItem           `json:"files"                    yaml:"files"`
 }
 
 // ConcurrencySettings represent settings for concurrent webhook executions to remote servers.

--- a/ndc-http-schema/configuration/types.go
+++ b/ndc-http-schema/configuration/types.go
@@ -212,8 +212,6 @@ type ConvertConfig struct {
 	EnvPrefix string `json:"envPrefix,omitempty" yaml:"envPrefix"`
 	// Return the pure NDC schema only
 	Pure bool `json:"pure,omitempty" yaml:"pure"`
-	// Require strict validation
-	Strict bool `json:"strict,omitempty" yaml:"strict"`
 	// Ignore deprecated fields.
 	NoDeprecation bool `json:"noDeprecation,omitempty" yaml:"noDeprecation"`
 	// Patch files to be applied into the input file before converting

--- a/ndc-http-schema/jsonschema/configuration.schema.json
+++ b/ndc-http-schema/jsonschema/configuration.schema.json
@@ -60,10 +60,6 @@
           "type": "boolean",
           "description": "Return the pure NDC schema only"
         },
-        "strict": {
-          "type": "boolean",
-          "description": "Require strict validation"
-        },
         "noDeprecation": {
           "type": "boolean",
           "description": "Ignore deprecated fields."
@@ -138,8 +134,6 @@
       "type": "object",
       "required": [
         "strict",
-        "forwardHeaders",
-        "concurrency",
         "files"
       ],
       "description": "Configuration contains required settings for the connector."

--- a/ndc-http-schema/jsonschema/convert-config.schema.json
+++ b/ndc-http-schema/jsonschema/convert-config.schema.json
@@ -36,10 +36,6 @@
           "type": "boolean",
           "description": "Return the pure NDC schema only"
         },
-        "strict": {
-          "type": "boolean",
-          "description": "Require strict validation"
-        },
         "noDeprecation": {
           "type": "boolean",
           "description": "Ignore deprecated fields."

--- a/ndc-http-schema/jsonschema/ndc-http-schema.schema.json
+++ b/ndc-http-schema/jsonschema/ndc-http-schema.schema.json
@@ -72,7 +72,9 @@
                 "literal"
               ]
             },
-            "value": true
+            "value": {
+              "description": "The literal value"
+            }
           },
           "type": "object",
           "required": [
@@ -89,7 +91,8 @@
               ]
             },
             "name": {
-              "type": "string"
+              "type": "string",
+              "description": "Environment variable name"
             }
           },
           "type": "object",
@@ -107,7 +110,8 @@
               ]
             },
             "name": {
-              "type": "string"
+              "type": "string",
+              "description": "Header name, require enable headers forwarding"
             }
           },
           "type": "object",
@@ -969,9 +973,6 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": [
-        "type"
-      ],
       "description": "TypeSchema represents a serializable object of OpenAPI schema that is used for validation"
     },
     "XMLSchema": {

--- a/ndc-http-schema/openapi/internal/oas2.go
+++ b/ndc-http-schema/openapi/internal/oas2.go
@@ -169,36 +169,24 @@ func (oc *OAS2Builder) pathToNDCOperations(pathItem orderedmap.Pair[string, *v2.
 		oc.schema.Functions[funcName] = *funcGet
 	}
 
-	procPost, procPostName, err := newOAS2OperationBuilder(oc, pathKey, "post").BuildProcedure(pathValue.Post, pathValue.Parameters)
+	err = newOAS2OperationBuilder(oc, pathKey, "post").BuildProcedure(pathValue.Post, pathValue.Parameters)
 	if err != nil {
 		return err
-	}
-	if procPost != nil {
-		oc.schema.Procedures[procPostName] = *procPost
 	}
 
-	procPut, procPutName, err := newOAS2OperationBuilder(oc, pathKey, "put").BuildProcedure(pathValue.Put, pathValue.Parameters)
+	err = newOAS2OperationBuilder(oc, pathKey, "put").BuildProcedure(pathValue.Put, pathValue.Parameters)
 	if err != nil {
 		return err
-	}
-	if procPut != nil {
-		oc.schema.Procedures[procPutName] = *procPut
 	}
 
-	procPatch, procPatchName, err := newOAS2OperationBuilder(oc, pathKey, "patch").BuildProcedure(pathValue.Patch, pathValue.Parameters)
+	err = newOAS2OperationBuilder(oc, pathKey, "patch").BuildProcedure(pathValue.Patch, pathValue.Parameters)
 	if err != nil {
 		return err
-	}
-	if procPatch != nil {
-		oc.schema.Procedures[procPatchName] = *procPatch
 	}
 
-	procDelete, procDeleteName, err := newOAS2OperationBuilder(oc, pathKey, "delete").BuildProcedure(pathValue.Delete, pathValue.Parameters)
+	err = newOAS2OperationBuilder(oc, pathKey, "delete").BuildProcedure(pathValue.Delete, pathValue.Parameters)
 	if err != nil {
 		return err
-	}
-	if procDelete != nil {
-		oc.schema.Procedures[procDeleteName] = *procDelete
 	}
 
 	return nil

--- a/ndc-http-schema/openapi/internal/oas2_operation.go
+++ b/ndc-http-schema/openapi/internal/oas2_operation.go
@@ -137,7 +137,7 @@ func (oc *oas2OperationBuilder) BuildProcedure(operation *v2.Operation, commonPa
 
 			if len(bodyTypes) > 1 {
 				bodyTypeName := getNamedType(bodyType.TypeRead, true, "")
-				newProcName = formatOperationName(procName + bodyTypeName)
+				newProcName = procName + "_" + strings.TrimPrefix(bodyTypeName, utils.ToPascalCase(procName))
 			}
 		}
 

--- a/ndc-http-schema/openapi/internal/oas2_schema.go
+++ b/ndc-http-schema/openapi/internal/oas2_schema.go
@@ -123,7 +123,7 @@ func (oc *oas2SchemaBuilder) getSchemaType(typeSchema *base.Schema, fieldPaths [
 	typeName := oasTypes[0]
 	switch typeName {
 	case "object":
-		typeResult, err = oc.evalObjectType(typeSchema, false, fieldPaths)
+		typeResult, err = oc.evalObjectType(typeSchema, fieldPaths)
 		if err != nil {
 			return nil, err
 		}
@@ -169,7 +169,7 @@ func (oc *oas2SchemaBuilder) getSchemaType(typeSchema *base.Schema, fieldPaths [
 	return typeResult, nil
 }
 
-func (oc *oas2SchemaBuilder) evalObjectType(baseSchema *base.Schema, forcePropertiesNullable bool, fieldPaths []string) (*SchemaInfoCache, error) {
+func (oc *oas2SchemaBuilder) evalObjectType(baseSchema *base.Schema, fieldPaths []string) (*SchemaInfoCache, error) {
 	typeResult := createSchemaFromOpenAPISchema(baseSchema)
 	refName := utils.StringSliceToPascalCase(fieldPaths)
 
@@ -217,7 +217,7 @@ func (oc *oas2SchemaBuilder) evalObjectType(baseSchema *base.Schema, forceProper
 			slog.String("name", propName),
 			slog.Any("field", fieldPaths))
 
-		nullable := forcePropertiesNullable || !slices.Contains(baseSchema.Required, propName)
+		nullable := !slices.Contains(baseSchema.Required, propName)
 		propResult, err := oc.getSchemaTypeFromProxy(prop.Value(), nullable, append(fieldPaths, propName))
 		if err != nil {
 			return nil, err
@@ -376,7 +376,7 @@ func (oc *oas2SchemaBuilder) buildUnionSchemaType(baseSchema *base.Schema, schem
 		}
 
 		if len(oasTypes) == 1 && baseSchema.Type[0] == "object" {
-			schemaResult, err := oc.evalObjectType(baseSchema, true, fieldPaths)
+			schemaResult, err := oc.evalObjectType(baseSchema, fieldPaths)
 			if err != nil {
 				return nil, err
 			}

--- a/ndc-http-schema/openapi/internal/oas2_schema.go
+++ b/ndc-http-schema/openapi/internal/oas2_schema.go
@@ -426,6 +426,8 @@ func (oc *oas2SchemaBuilder) buildUnionSchemaType(baseSchema *base.Schema, schem
 
 	var readObjectItems []rest.ObjectType
 	var writeObjectItems []rest.ObjectType
+	var oneOfInfos []SchemaInfoCache
+	var isJSON bool
 
 	for i, item := range proxies {
 		schemaResult, err := newOAS2SchemaBuilder(oc.builder, oc.apiPath, oc.location).
@@ -443,20 +445,17 @@ func (oc *oas2SchemaBuilder) buildUnionSchemaType(baseSchema *base.Schema, schem
 				readObjectItems = append(readObjectItems, readObj)
 			}
 		}
+		if unionType == oasOneOf && schemaResult != nil {
+			oneOfInfos = append(oneOfInfos, *schemaResult)
+		}
 
 		if !isObject {
-			schemaResult.TypeSchema = &rest.TypeSchema{
-				Description: typeSchema.Description,
-				Type:        []string{},
+			isJSON = true
+			if unionType == oasOneOf {
+				continue
 			}
 
-			jsonScalar := oc.builder.buildScalarJSON()
-
-			return &SchemaInfoCache{
-				TypeRead:   jsonScalar,
-				TypeWrite:  jsonScalar,
-				TypeSchema: schemaResult.TypeSchema,
-			}, nil
+			break
 		}
 
 		writeName := formatWriteObjectName(name)
@@ -466,6 +465,19 @@ func (oc *oas2SchemaBuilder) buildUnionSchemaType(baseSchema *base.Schema, schem
 		}
 
 		writeObjectItems = append(writeObjectItems, writeObj)
+	}
+	if isJSON {
+		jsonScalar := oc.builder.buildScalarJSON()
+
+		return &SchemaInfoCache{
+			TypeRead:  jsonScalar,
+			TypeWrite: jsonScalar,
+			OneOf:     oneOfInfos,
+			TypeSchema: &rest.TypeSchema{
+				Description: typeSchema.Description,
+				Type:        []string{},
+			},
+		}, nil
 	}
 
 	readObject := rest.ObjectType{
@@ -501,6 +513,7 @@ func (oc *oas2SchemaBuilder) buildUnionSchemaType(baseSchema *base.Schema, schem
 		TypeRead:   schema.NewNamedType(refName),
 		TypeWrite:  schema.NewNamedType(writeRefName),
 		TypeSchema: typeSchema,
+		OneOf:      oneOfInfos,
 	}, nil
 }
 

--- a/ndc-http-schema/openapi/internal/oas3.go
+++ b/ndc-http-schema/openapi/internal/oas3.go
@@ -305,14 +305,6 @@ func (oc *OAS3Builder) convertComponentSchemas(schemaItem orderedmap.Pair[string
 	return err
 }
 
-func (oc *OAS3Builder) trimPathPrefix(input string) string {
-	if oc.ConvertOptions.TrimPrefix == "" {
-		return input
-	}
-
-	return strings.TrimPrefix(input, oc.ConvertOptions.TrimPrefix)
-}
-
 // build a named type for JSON scalar
 func (oc *OAS3Builder) buildScalarJSON() *schema.NamedType {
 	scalarName := string(rest.ScalarJSON)

--- a/ndc-http-schema/openapi/internal/oas3.go
+++ b/ndc-http-schema/openapi/internal/oas3.go
@@ -32,6 +32,7 @@ type SchemaInfoCache struct {
 	TypeRead   schema.TypeEncoder
 	TypeWrite  schema.TypeEncoder
 	TypeSchema *rest.TypeSchema
+	OneOf      []SchemaInfoCache
 }
 
 // NewOAS3Builder creates an OAS3Builder instance
@@ -214,36 +215,24 @@ func (oc *OAS3Builder) pathToNDCOperations(pathItem orderedmap.Pair[string, *v3.
 		}
 	}
 
-	procPost, procPostName, err := newOAS3OperationBuilder(oc, pathKey, "post", pathValue.Parameters).BuildProcedure(pathValue.Post)
+	err := newOAS3OperationBuilder(oc, pathKey, "post", pathValue.Parameters).BuildProcedure(pathValue.Post)
 	if err != nil {
 		return err
-	}
-	if procPost != nil {
-		oc.schema.Procedures[procPostName] = *procPost
 	}
 
-	procPut, procPutName, err := newOAS3OperationBuilder(oc, pathKey, "put", pathValue.Parameters).BuildProcedure(pathValue.Put)
+	err = newOAS3OperationBuilder(oc, pathKey, "put", pathValue.Parameters).BuildProcedure(pathValue.Put)
 	if err != nil {
 		return err
-	}
-	if procPut != nil {
-		oc.schema.Procedures[procPutName] = *procPut
 	}
 
-	procPatch, procPutName, err := newOAS3OperationBuilder(oc, pathKey, "patch", pathValue.Parameters).BuildProcedure(pathValue.Patch)
+	err = newOAS3OperationBuilder(oc, pathKey, "patch", pathValue.Parameters).BuildProcedure(pathValue.Patch)
 	if err != nil {
 		return err
-	}
-	if procPatch != nil {
-		oc.schema.Procedures[procPutName] = *procPatch
 	}
 
-	procDelete, procDeleteName, err := newOAS3OperationBuilder(oc, pathKey, "delete", pathValue.Parameters).BuildProcedure(pathValue.Delete)
+	err = newOAS3OperationBuilder(oc, pathKey, "delete", pathValue.Parameters).BuildProcedure(pathValue.Delete)
 	if err != nil {
 		return err
-	}
-	if procDelete != nil {
-		oc.schema.Procedures[procDeleteName] = *procDelete
 	}
 
 	return nil

--- a/ndc-http-schema/openapi/internal/oas3_operation.go
+++ b/ndc-http-schema/openapi/internal/oas3_operation.go
@@ -159,7 +159,7 @@ func (oc *oas3OperationBuilder) BuildProcedure(operation *v3.Operation) error {
 
 			if len(bodyTypes) > 1 {
 				bodyTypeName := getNamedType(bodyType.TypeRead, true, "")
-				newProcName = formatOperationName(procName + bodyTypeName)
+				newProcName = procName + "_" + strings.TrimPrefix(bodyTypeName, utils.ToPascalCase(procName))
 			}
 		}
 

--- a/ndc-http-schema/openapi/internal/oas3_schema.go
+++ b/ndc-http-schema/openapi/internal/oas3_schema.go
@@ -107,21 +107,15 @@ func (oc *oas3SchemaBuilder) getSchemaType(typeSchema *base.Schema, fieldPaths [
 		return oc.buildUnionSchemaType(typeSchema, typeSchema.OneOf, oasOneOf, fieldPaths)
 	}
 
-	if typeSchema.AdditionalProperties != nil && (typeSchema.AdditionalProperties.B || typeSchema.AdditionalProperties.A != nil) {
-		return &SchemaInfoCache{
-			TypeRead:   oc.builder.buildScalarJSON(),
-			TypeWrite:  oc.builder.buildScalarJSON(),
-			TypeSchema: createSchemaFromOpenAPISchema(typeSchema),
-		}, nil
-	}
-
-	if len(typeSchema.Type) == 0 {
-		if oc.builder.Strict {
+	oasTypes, nullable := extractNullableFromOASTypes(typeSchema.Type)
+	nullable = nullable || (typeSchema.Nullable != nil && *typeSchema.Nullable)
+	if len(oasTypes) == 0 || (typeSchema.AdditionalProperties != nil && (typeSchema.AdditionalProperties.B || typeSchema.AdditionalProperties.A != nil)) {
+		if len(typeSchema.Type) == 0 && oc.builder.Strict {
 			return nil, errParameterSchemaEmpty(fieldPaths)
 		}
 
 		var result schema.TypeEncoder = oc.builder.buildScalarJSON()
-		if typeSchema.Nullable != nil && *typeSchema.Nullable {
+		if nullable {
 			result = schema.NewNullableType(result)
 		}
 
@@ -132,10 +126,10 @@ func (oc *oas3SchemaBuilder) getSchemaType(typeSchema *base.Schema, fieldPaths [
 		}, nil
 	}
 
-	if len(typeSchema.Type) > 1 || isPrimitiveScalar(typeSchema.Type) {
-		scalarName, nullable := getScalarFromType(oc.builder.schema, typeSchema.Type, typeSchema.Format, typeSchema.Enum, oc.builder.trimPathPrefix(oc.apiPath), fieldPaths)
+	if len(oasTypes) > 1 || isPrimitiveScalar(oasTypes) {
+		scalarName := getScalarFromType(oc.builder.schema, oasTypes, typeSchema.Format, typeSchema.Enum, oc.builder.trimPathPrefix(oc.apiPath), fieldPaths)
 		var resultType schema.TypeEncoder = schema.NewNamedType(scalarName)
-		if nullable || (typeSchema.Nullable != nil && *typeSchema.Nullable) {
+		if nullable {
 			resultType = schema.NewNullableType(resultType)
 		}
 
@@ -146,14 +140,13 @@ func (oc *oas3SchemaBuilder) getSchemaType(typeSchema *base.Schema, fieldPaths [
 		}, nil
 	}
 
-	typeName := typeSchema.Type[0]
+	typeName := oasTypes[0]
 	switch typeName {
 	case "object":
 		return oc.evalObjectType(typeSchema, false, fieldPaths)
 	case "array":
 		var itemSchema *SchemaInfoCache
 		var err error
-		nullable := (typeSchema.Nullable != nil && *typeSchema.Nullable)
 		if typeSchema.Items == nil || typeSchema.Items.A == nil {
 			if oc.builder.Strict {
 				return nil, fmt.Errorf("%s: array item is empty", strings.Join(fieldPaths, "."))
@@ -320,10 +313,11 @@ func (oc *oas3SchemaBuilder) buildUnionSchemaType(baseSchema *base.Schema, schem
 
 	switch len(proxies) {
 	case 0:
+		oasTypes, isNullable := extractNullableFromOASTypes(baseSchema.Type)
 		if len(baseSchema.Type) > 1 || isPrimitiveScalar(baseSchema.Type) {
-			scalarName, nullable := getScalarFromType(oc.builder.schema, baseSchema.Type, baseSchema.Format, baseSchema.Enum, oc.builder.trimPathPrefix(oc.apiPath), fieldPaths)
+			scalarName := getScalarFromType(oc.builder.schema, oasTypes, baseSchema.Format, baseSchema.Enum, oc.builder.trimPathPrefix(oc.apiPath), fieldPaths)
 			var result schema.TypeEncoder = schema.NewNamedType(scalarName)
-			if nullable {
+			if nullable || isNullable {
 				result = schema.NewNullableType(result)
 			}
 
@@ -334,12 +328,22 @@ func (oc *oas3SchemaBuilder) buildUnionSchemaType(baseSchema *base.Schema, schem
 			}, nil
 		}
 
-		if len(baseSchema.Type) == 1 && baseSchema.Type[0] == "object" {
-			return oc.evalObjectType(baseSchema, true, fieldPaths)
+		if len(oasTypes) == 1 && baseSchema.Type[0] == "object" {
+			schemaResult, err := oc.evalObjectType(baseSchema, true, fieldPaths)
+			if err != nil {
+				return nil, err
+			}
+
+			if nullable || isNullable {
+				schemaResult.TypeRead = schema.NewNullableType(schemaResult.TypeRead)
+				schemaResult.TypeWrite = schema.NewNullableType(schemaResult.TypeWrite)
+			}
+
+			return schemaResult, nil
 		}
 
 		var result schema.TypeEncoder = schema.NewNamedType(string(rest.ScalarJSON))
-		if nullable {
+		if nullable || isNullable {
 			result = schema.NewNullableType(result)
 		}
 

--- a/ndc-http-schema/openapi/internal/oas3_schema.go
+++ b/ndc-http-schema/openapi/internal/oas3_schema.go
@@ -145,7 +145,7 @@ func (oc *oas3SchemaBuilder) getSchemaType(typeSchema *base.Schema, fieldPaths [
 	typeName := oasTypes[0]
 	switch typeName {
 	case "object":
-		typeResult, err = oc.evalObjectType(typeSchema, false, fieldPaths)
+		typeResult, err = oc.evalObjectType(typeSchema, fieldPaths)
 		if err != nil {
 			return nil, err
 		}
@@ -190,7 +190,7 @@ func (oc *oas3SchemaBuilder) getSchemaType(typeSchema *base.Schema, fieldPaths [
 	return typeResult, nil
 }
 
-func (oc *oas3SchemaBuilder) evalObjectType(baseSchema *base.Schema, forcePropertiesNullable bool, fieldPaths []string) (*SchemaInfoCache, error) {
+func (oc *oas3SchemaBuilder) evalObjectType(baseSchema *base.Schema, fieldPaths []string) (*SchemaInfoCache, error) {
 	typeResult := createSchemaFromOpenAPISchema(baseSchema)
 	refName := utils.StringSliceToPascalCase(fieldPaths)
 	if baseSchema.Properties == nil || baseSchema.Properties.IsZero() {
@@ -227,7 +227,7 @@ func (oc *oas3SchemaBuilder) evalObjectType(baseSchema *base.Schema, forceProper
 			"property",
 			slog.String("name", propName),
 			slog.Any("field", fieldPaths))
-		nullable := forcePropertiesNullable || !slices.Contains(baseSchema.Required, propName)
+		nullable := !slices.Contains(baseSchema.Required, propName)
 		propResult, err := oc.getSchemaTypeFromProxy(prop.Value(), nullable, append(fieldPaths, propName))
 		if err != nil {
 			return nil, err
@@ -333,7 +333,7 @@ func (oc *oas3SchemaBuilder) buildUnionSchemaType(baseSchema *base.Schema, schem
 		}
 
 		if len(oasTypes) == 1 && baseSchema.Type[0] == "object" {
-			schemaResult, err := oc.evalObjectType(baseSchema, true, fieldPaths)
+			schemaResult, err := oc.evalObjectType(baseSchema, fieldPaths)
 			if err != nil {
 				return nil, err
 			}

--- a/ndc-http-schema/openapi/internal/oas3_schema.go
+++ b/ndc-http-schema/openapi/internal/oas3_schema.go
@@ -365,18 +365,8 @@ func (oc *oas3SchemaBuilder) buildUnionSchemaType(baseSchema *base.Schema, schem
 		return result, nil
 	}
 
-	typeSchema := &rest.TypeSchema{
-		Type: []string{"object"},
-	}
-
-	if baseSchema.Description != "" {
-		typeSchema.Description = utils.StripHTMLTags(baseSchema.Description)
-	}
-
-	var readObjectItems []rest.ObjectType
-	var writeObjectItems []rest.ObjectType
+	var unionSchemas []SchemaInfoCache
 	var oneOfInfos []SchemaInfoCache
-	var isJSON bool
 
 	for i, item := range proxies {
 		schemaResult, err := newOAS3SchemaBuilder(oc.builder, oc.apiPath, oc.location).
@@ -385,86 +375,14 @@ func (oc *oas3SchemaBuilder) buildUnionSchemaType(baseSchema *base.Schema, schem
 			return nil, err
 		}
 
-		var readObj rest.ObjectType
-		name := getNamedType(schemaResult.TypeRead, false, "")
-		isObject := name != "" && !isPrimitiveScalar(schemaResult.TypeSchema.Type) && !slices.Contains(schemaResult.TypeSchema.Type, "array")
-		if isObject {
-			readObj, isObject = oc.builder.schema.ObjectTypes[name]
-			if isObject {
-				readObjectItems = append(readObjectItems, readObj)
-			}
-		}
-
+		unionSchemas = append(unionSchemas, *schemaResult)
 		if unionType == oasOneOf && schemaResult != nil {
 			oneOfInfos = append(oneOfInfos, *schemaResult)
 		}
-
-		if !isObject {
-			isJSON = true
-
-			if unionType == oasOneOf {
-				continue
-			}
-
-			break
-		}
-
-		writeName := formatWriteObjectName(name)
-		writeObj, ok := oc.builder.schema.ObjectTypes[writeName]
-		if !ok {
-			writeObj = readObj
-		}
-
-		writeObjectItems = append(writeObjectItems, writeObj)
 	}
 
-	if isJSON {
-		jsonScalar := oc.builder.buildScalarJSON()
+	result := mergeUnionTypeSchemas(oc.builder.schema, baseSchema, unionSchemas, unionType, fieldPaths)
+	result.OneOf = oneOfInfos
 
-		return &SchemaInfoCache{
-			TypeRead:  jsonScalar,
-			TypeWrite: jsonScalar,
-			OneOf:     oneOfInfos,
-			TypeSchema: &rest.TypeSchema{
-				Description: typeSchema.Description,
-				Type:        []string{},
-			},
-		}, nil
-	}
-
-	readObject := rest.ObjectType{
-		Fields: map[string]rest.ObjectField{},
-	}
-	writeObject := rest.ObjectType{
-		Fields: map[string]rest.ObjectField{},
-	}
-
-	if baseSchema.Description != "" {
-		readObject.Description = &baseSchema.Description
-		writeObject.Description = &baseSchema.Description
-	}
-
-	if err := mergeUnionObjects(oc.builder.schema, &readObject, readObjectItems, unionType, fieldPaths); err != nil {
-		return nil, err
-	}
-
-	if err := mergeUnionObjects(oc.builder.schema, &writeObject, writeObjectItems, unionType, fieldPaths); err != nil {
-		return nil, err
-	}
-
-	refName := utils.ToPascalCase(strings.Join(fieldPaths, " "))
-	writeRefName := formatWriteObjectName(refName)
-	if len(readObject.Fields) > 0 {
-		oc.builder.schema.ObjectTypes[refName] = readObject
-	}
-	if len(writeObject.Fields) > 0 {
-		oc.builder.schema.ObjectTypes[writeRefName] = writeObject
-	}
-
-	return &SchemaInfoCache{
-		TypeRead:   schema.NewNamedType(refName),
-		TypeWrite:  schema.NewNamedType(writeRefName),
-		TypeSchema: typeSchema,
-		OneOf:      oneOfInfos,
-	}, nil
+	return result, nil
 }

--- a/ndc-http-schema/openapi/internal/oas3_schema.go
+++ b/ndc-http-schema/openapi/internal/oas3_schema.go
@@ -140,13 +140,17 @@ func (oc *oas3SchemaBuilder) getSchemaType(typeSchema *base.Schema, fieldPaths [
 		}, nil
 	}
 
+	var typeResult *SchemaInfoCache
+	var err error
 	typeName := oasTypes[0]
 	switch typeName {
 	case "object":
-		return oc.evalObjectType(typeSchema, false, fieldPaths)
+		typeResult, err = oc.evalObjectType(typeSchema, false, fieldPaths)
+		if err != nil {
+			return nil, err
+		}
 	case "array":
 		var itemSchema *SchemaInfoCache
-		var err error
 		if typeSchema.Items == nil || typeSchema.Items.A == nil {
 			if oc.builder.Strict {
 				return nil, fmt.Errorf("%s: array item is empty", strings.Join(fieldPaths, "."))
@@ -165,7 +169,7 @@ func (oc *oas3SchemaBuilder) getSchemaType(typeSchema *base.Schema, fieldPaths [
 			}
 		}
 
-		typeResult := &SchemaInfoCache{
+		typeResult = &SchemaInfoCache{
 			TypeSchema: createSchemaFromOpenAPISchema(typeSchema),
 			TypeRead:   schema.NewArrayType(itemSchema.TypeRead),
 			TypeWrite:  schema.NewArrayType(itemSchema.TypeWrite),
@@ -174,16 +178,16 @@ func (oc *oas3SchemaBuilder) getSchemaType(typeSchema *base.Schema, fieldPaths [
 		if itemSchema.TypeSchema != nil {
 			typeResult.TypeSchema.Items = itemSchema.TypeSchema
 		}
-
-		if nullable {
-			typeResult.TypeRead = schema.NewNullableType(typeResult.TypeRead)
-			typeResult.TypeWrite = schema.NewNullableType(typeResult.TypeWrite)
-		}
-
-		return typeResult, nil
 	default:
 		return nil, fmt.Errorf("unsupported schema type %s", typeName)
 	}
+
+	if nullable {
+		typeResult.TypeRead = schema.NewNullableType(typeResult.TypeRead)
+		typeResult.TypeWrite = schema.NewNullableType(typeResult.TypeWrite)
+	}
+
+	return typeResult, nil
 }
 
 func (oc *oas3SchemaBuilder) evalObjectType(baseSchema *base.Schema, forcePropertiesNullable bool, fieldPaths []string) (*SchemaInfoCache, error) {

--- a/ndc-http-schema/openapi/internal/oas_utils.go
+++ b/ndc-http-schema/openapi/internal/oas_utils.go
@@ -67,6 +67,10 @@ func getScalarFromType(sm *rest.NDCHttpSchema, names []string, format string, en
 func buildEnumScalar(sm *rest.NDCHttpSchema, enumNodes []*yaml.Node, fieldPaths []string) (string, *schema.ScalarType) {
 	enums := make([]string, len(enumNodes))
 	for i, enum := range enumNodes {
+		if enum.Value == "null" {
+			continue
+		}
+
 		enums[i] = enum.Value
 	}
 

--- a/ndc-http-schema/openapi/internal/oas_utils.go
+++ b/ndc-http-schema/openapi/internal/oas_utils.go
@@ -1,0 +1,376 @@
+package internal
+
+import (
+	"slices"
+	"strings"
+
+	rest "github.com/hasura/ndc-http/ndc-http-schema/schema"
+	"github.com/hasura/ndc-http/ndc-http-schema/utils"
+	"github.com/hasura/ndc-sdk-go/schema"
+	"github.com/pb33f/libopenapi/datamodel/high/base"
+	"gopkg.in/yaml.v3"
+)
+
+func getSchemaRefTypeNameV2(name string) string {
+	result := schemaRefNameV2Regexp.FindStringSubmatch(name)
+	if len(result) < 2 {
+		return ""
+	}
+
+	return result[1]
+}
+
+func getSchemaRefTypeNameV3(name string) string {
+	result := schemaRefNameV3Regexp.FindStringSubmatch(name)
+	if len(result) < 2 {
+		return ""
+	}
+
+	return result[1]
+}
+
+func extractNullableFromOASTypes(names []string) ([]string, bool) {
+	var typeNames []string
+	var nullable bool
+
+	for _, name := range names {
+		if name == "null" {
+			nullable = true
+		} else {
+			typeNames = append(typeNames, name)
+		}
+	}
+
+	return typeNames, nullable
+}
+
+func getScalarFromType(sm *rest.NDCHttpSchema, names []string, format string, enumNodes []*yaml.Node, fieldPaths []string) string {
+	var scalarName string
+	var scalarType *schema.ScalarType
+
+	namesLen := len(names)
+	switch {
+	case namesLen == 0 && len(enumNodes) > 0:
+		scalarName, scalarType = buildEnumScalar(sm, enumNodes, fieldPaths)
+	case namesLen == 1:
+		scalarName, scalarType = getScalarFromOASType(sm, names, format, enumNodes, fieldPaths)
+	default:
+		scalarName = string(rest.ScalarJSON)
+		scalarType = defaultScalarTypes[rest.ScalarJSON]
+	}
+
+	sm.AddScalar(scalarName, *scalarType)
+
+	return scalarName
+}
+
+func buildEnumScalar(sm *rest.NDCHttpSchema, enumNodes []*yaml.Node, fieldPaths []string) (string, *schema.ScalarType) {
+	enums := make([]string, len(enumNodes))
+	for i, enum := range enumNodes {
+		enums[i] = enum.Value
+	}
+
+	scalarType := schema.NewScalarType()
+	scalarType.Representation = schema.NewTypeRepresentationEnum(enums).Encode()
+
+	scalarName := utils.StringSliceToPascalCase(fieldPaths)
+	if canSetEnumToSchema(sm, scalarName, enums) {
+		return scalarName, scalarType
+	}
+
+	// if the name exists, add enum above name with Enum suffix
+	scalarName += "Enum"
+
+	return scalarName, scalarType
+}
+
+func getScalarFromOASType(sm *rest.NDCHttpSchema, names []string, format string, enumNodes []*yaml.Node, fieldPaths []string) (string, *schema.ScalarType) {
+	var scalarName string
+	var scalarType *schema.ScalarType
+
+	switch names[0] {
+	case "boolean":
+		scalarName = string(rest.ScalarBoolean)
+		scalarType = defaultScalarTypes[rest.ScalarBoolean]
+	case "integer":
+		switch format {
+		case "unix-time":
+			scalarName = string(rest.ScalarUnixTime)
+			scalarType = defaultScalarTypes[rest.ScalarUnixTime]
+		case "int64":
+			scalarName = string(rest.ScalarInt64)
+			scalarType = defaultScalarTypes[rest.ScalarInt64]
+		default:
+			scalarName = string(rest.ScalarInt32)
+			scalarType = defaultScalarTypes[rest.ScalarInt32]
+		}
+	case "long":
+		scalarName = string(rest.ScalarInt64)
+		scalarType = defaultScalarTypes[rest.ScalarInt64]
+	case "number":
+		switch format {
+		case "float":
+			scalarName = string(rest.ScalarFloat32)
+			scalarType = defaultScalarTypes[rest.ScalarFloat32]
+		default:
+			scalarName = string(rest.ScalarFloat64)
+			scalarType = defaultScalarTypes[rest.ScalarFloat64]
+		}
+	case "file":
+		scalarName = string(rest.ScalarBinary)
+		scalarType = defaultScalarTypes[rest.ScalarBinary]
+	case "string":
+		if len(enumNodes) > 0 {
+			return buildEnumScalar(sm, enumNodes, fieldPaths)
+		}
+
+		switch format {
+		case "date":
+			scalarName = string(rest.ScalarDate)
+			scalarType = defaultScalarTypes[rest.ScalarDate]
+		case "date-time":
+			scalarName = string(rest.ScalarTimestampTZ)
+			scalarType = defaultScalarTypes[rest.ScalarTimestampTZ]
+		case "byte", "base64":
+			scalarName = string(rest.ScalarBytes)
+			scalarType = defaultScalarTypes[rest.ScalarBytes]
+		case "binary":
+			scalarName = string(rest.ScalarBinary)
+			scalarType = defaultScalarTypes[rest.ScalarBinary]
+		case "uuid":
+			scalarName = string(rest.ScalarUUID)
+			scalarType = defaultScalarTypes[rest.ScalarUUID]
+		case "uri":
+			scalarName = string(rest.ScalarURI)
+			scalarType = defaultScalarTypes[rest.ScalarURI]
+		case "ipv4":
+			scalarName = string(rest.ScalarIPV4)
+			scalarType = defaultScalarTypes[rest.ScalarIPV4]
+		case "ipv6":
+			scalarName = string(rest.ScalarIPV6)
+			scalarType = defaultScalarTypes[rest.ScalarIPV6]
+		default:
+			scalarName = string(rest.ScalarString)
+			scalarType = defaultScalarTypes[rest.ScalarString]
+		}
+	default:
+		scalarName = string(rest.ScalarJSON)
+		scalarType = defaultScalarTypes[rest.ScalarJSON]
+	}
+
+	return scalarName, scalarType
+}
+
+func canSetEnumToSchema(sm *rest.NDCHttpSchema, scalarName string, enums []string) bool {
+	existedScalar, ok := sm.ScalarTypes[scalarName]
+	if !ok {
+		return true
+	}
+
+	existedEnum, err := existedScalar.Representation.AsEnum()
+	if err == nil && utils.SliceUnorderedEqual(enums, existedEnum.OneOf) {
+		return true
+	}
+
+	return false
+}
+
+// remove nullable types from raw OpenAPI types
+func evaluateOpenAPITypes(input []string) []string {
+	var typeNames []string
+	for _, t := range input {
+		if t != "null" {
+			typeNames = append(typeNames, t)
+		}
+	}
+
+	return typeNames
+}
+
+func createSchemaFromOpenAPISchema(input *base.Schema) *rest.TypeSchema {
+	ps := &rest.TypeSchema{
+		Type: []string{},
+	}
+	if input == nil {
+		return ps
+	}
+	ps.Type = evaluateOpenAPITypes(input.Type)
+	ps.Format = input.Format
+	ps.Pattern = utils.RemoveYAMLSpecialCharacters([]byte(input.Pattern))
+	ps.Maximum = input.Maximum
+	ps.Minimum = input.Minimum
+	ps.MaxLength = input.MaxLength
+	ps.MinLength = input.MinLength
+	ps.Description = utils.StripHTMLTags(input.Description)
+	ps.ReadOnly = input.ReadOnly != nil && *input.ReadOnly
+	ps.WriteOnly = input.WriteOnly != nil && *input.WriteOnly
+
+	if input.XML != nil {
+		ps.XML = &rest.XMLSchema{
+			Name:      input.XML.Name,
+			Prefix:    input.XML.Prefix,
+			Namespace: input.XML.Namespace,
+			Wrapped:   input.XML.Wrapped,
+			Attribute: input.XML.Attribute,
+		}
+	}
+
+	return ps
+}
+
+// check if the OAS type is a scalar
+func isPrimitiveScalar(names []string) bool {
+	for _, name := range names {
+		if !slices.Contains([]string{"boolean", "integer", "number", "string", "file", "long", "null"}, name) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Find common fields in all objects to merge the type.
+// If they have the same type, we don't need to wrap it with the nullable type.
+func mergeUnionObjects(httpSchema *rest.NDCHttpSchema, dest *rest.ObjectType, srcObjects []rest.ObjectType, unionType oasUnionType, fieldPaths []string) {
+	mergedObjectFields := make(map[string][]rest.ObjectField)
+	for _, object := range srcObjects {
+		for key, field := range object.Fields {
+			mergedObjectFields[key] = append(mergedObjectFields[key], field)
+		}
+	}
+
+	for key, fields := range mergedObjectFields {
+		if len(fields) == 1 {
+			newField := rest.ObjectField{
+				ObjectField: schema.ObjectField{
+					Description: fields[0].Description,
+					Arguments:   fields[0].Arguments,
+					Type:        fields[0].Type,
+				},
+				HTTP: fields[0].HTTP,
+			}
+
+			if unionType != oasAllOf && !isNullableType(newField.Type.Interface()) {
+				newField.Type = (schema.NullableType{
+					Type:           schema.TypeNullable,
+					UnderlyingType: newField.Type,
+				}).Encode()
+			}
+
+			dest.Fields[key] = newField
+
+			continue
+		}
+
+		var unionField rest.ObjectField
+		for i, field := range fields {
+			if i == 0 {
+				unionField = field
+
+				continue
+			}
+
+			unionType, ok := mergeUnionTypes(httpSchema, field.Type, unionField.Type, append(fieldPaths, key))
+			unionField.Type = unionType.Encode()
+			if !ok {
+				break
+			}
+
+			if unionField.Description == nil && field.Description != nil {
+				unionField.Description = field.Description
+			}
+
+			if unionField.HTTP == nil && field.HTTP != nil {
+				unionField.HTTP = field.HTTP
+			}
+		}
+
+		if len(fields) < len(srcObjects) && unionType != oasAllOf && !isNullableType(unionField.Type.Interface()) {
+			unionField.Type = (schema.NullableType{
+				Type:           schema.TypeNullable,
+				UnderlyingType: unionField.Type,
+			}).Encode()
+		}
+
+		dest.Fields[key] = unionField
+	}
+}
+
+// evaluate and filter invalid types in allOf, anyOf or oneOf schemas
+func evalSchemaProxiesSlice(schemaProxies []*base.SchemaProxy, location rest.ParameterLocation) ([]*base.SchemaProxy, *base.Schema, bool, bool) {
+	var results []*base.SchemaProxy
+	var typeNames []string
+	var nullable, isEmptyObject bool
+
+	for _, proxy := range schemaProxies {
+		if proxy == nil {
+			continue
+		}
+		sc := proxy.Schema()
+		if sc == nil || (len(sc.Type) == 0 && len(sc.AllOf) == 0 && len(sc.AnyOf) == 0 && len(sc.OneOf) == 0) {
+			continue
+		}
+
+		// empty string enum is considered as nullable, e.g. key1=&key2=
+		// however, it's redundant and prevents the tool converting correct types
+		if (len(sc.Type) == 1 && sc.Type[0] == "null") ||
+			(location == rest.InQuery && (sc.Type[0] == "string" && len(sc.Enum) == 1 && (sc.Enum[0] == nil || sc.Enum[0].Value == ""))) {
+			nullable = true
+
+			continue
+		}
+
+		if len(sc.Type) == 1 && sc.Type[0] == "object" && (sc.Properties == nil || sc.Properties.Len() == 0) &&
+			(sc.AdditionalProperties == nil || !sc.AdditionalProperties.B) {
+			isEmptyObject = true
+
+			continue
+		}
+
+		results = append(results, proxy)
+		if len(sc.Type) == 0 {
+			typeNames = append(typeNames, "any")
+		} else if !slices.Contains(typeNames, sc.Type[0]) {
+			typeNames = append(typeNames, sc.Type[0])
+		}
+	}
+
+	if len(typeNames) == 1 && len(results) > 1 && typeNames[0] == "string" {
+		// if the anyOf array contains both string and enum
+		// we can cast them to string
+		return nil, &base.Schema{
+			Type: typeNames,
+		}, nullable, isEmptyObject
+	}
+
+	return results, nil, nullable, isEmptyObject
+}
+
+// guess the result type from content type
+func getResultTypeFromContentType(httpSchema *rest.NDCHttpSchema, contentType string) schema.TypeEncoder {
+	var scalarName rest.ScalarName
+	switch {
+	case strings.HasPrefix(contentType, "text/"):
+		scalarName = rest.ScalarString
+	case contentType == rest.ContentTypeOctetStream || strings.HasPrefix(contentType, "image/") || strings.HasPrefix(contentType, "video/"):
+		scalarName = rest.ScalarBinary
+	default:
+		scalarName = rest.ScalarJSON
+	}
+
+	httpSchema.AddScalar(string(scalarName), *defaultScalarTypes[scalarName])
+
+	return schema.NewNamedType(string(scalarName))
+}
+
+func guessScalarResultTypeFromContentType(contentType string) rest.ScalarName {
+	ct := strings.TrimSpace(strings.Split(contentType, ";")[0])
+	switch {
+	case utils.IsContentTypeJSON(ct) || utils.IsContentTypeXML(ct) || ct == rest.ContentTypeNdJSON:
+		return rest.ScalarJSON
+	case utils.IsContentTypeText(ct):
+		return rest.ScalarString
+	default:
+		return rest.ScalarBinary
+	}
+}

--- a/ndc-http-schema/openapi/internal/types.go
+++ b/ndc-http-schema/openapi/internal/types.go
@@ -180,7 +180,6 @@ type ConvertOptions struct {
 	Prefix              string
 	TrimPrefix          string
 	EnvPrefix           string
-	Strict              bool
 	NoDeprecation       bool
 	Logger              *slog.Logger
 }

--- a/ndc-http-schema/openapi/internal/utils.go
+++ b/ndc-http-schema/openapi/internal/utils.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hasura/ndc-sdk-go/schema"
 	sdkUtils "github.com/hasura/ndc-sdk-go/utils"
 	"github.com/pb33f/libopenapi/datamodel/high/base"
-	"gopkg.in/yaml.v3"
 )
 
 func applyConvertOptions(opts ConvertOptions) *ConvertOptions {
@@ -35,213 +34,6 @@ func buildPathMethodName(apiPath string, method string, options *ConvertOptions)
 	}
 
 	return utils.ToCamelCase(method + encodedPath)
-}
-
-func getSchemaRefTypeNameV2(name string) string {
-	result := schemaRefNameV2Regexp.FindStringSubmatch(name)
-	if len(result) < 2 {
-		return ""
-	}
-
-	return result[1]
-}
-
-func getSchemaRefTypeNameV3(name string) string {
-	result := schemaRefNameV3Regexp.FindStringSubmatch(name)
-	if len(result) < 2 {
-		return ""
-	}
-
-	return result[1]
-}
-
-func extractNullableFromOASTypes(names []string) ([]string, bool) {
-	var typeNames []string
-	var nullable bool
-
-	for _, name := range names {
-		if name == "null" {
-			nullable = true
-		} else {
-			typeNames = append(typeNames, name)
-		}
-	}
-
-	return typeNames, nullable
-}
-
-func getScalarFromType(sm *rest.NDCHttpSchema, names []string, format string, enumNodes []*yaml.Node, fieldPaths []string) string {
-	var scalarName string
-	var scalarType *schema.ScalarType
-
-	namesLen := len(names)
-	switch {
-	case namesLen == 0 && len(enumNodes) > 0:
-		scalarName, scalarType = buildEnumScalar(sm, enumNodes, fieldPaths)
-	case namesLen == 1:
-		scalarName, scalarType = getScalarFromOASType(sm, names, format, enumNodes, fieldPaths)
-	default:
-		scalarName = string(rest.ScalarJSON)
-		scalarType = defaultScalarTypes[rest.ScalarJSON]
-	}
-
-	sm.AddScalar(scalarName, *scalarType)
-
-	return scalarName
-}
-
-func buildEnumScalar(sm *rest.NDCHttpSchema, enumNodes []*yaml.Node, fieldPaths []string) (string, *schema.ScalarType) {
-	enums := make([]string, len(enumNodes))
-	for i, enum := range enumNodes {
-		enums[i] = enum.Value
-	}
-
-	scalarType := schema.NewScalarType()
-	scalarType.Representation = schema.NewTypeRepresentationEnum(enums).Encode()
-
-	scalarName := utils.StringSliceToPascalCase(fieldPaths)
-	if canSetEnumToSchema(sm, scalarName, enums) {
-		return scalarName, scalarType
-	}
-
-	// if the name exists, add enum above name with Enum suffix
-	scalarName += "Enum"
-
-	return scalarName, scalarType
-}
-
-func getScalarFromOASType(sm *rest.NDCHttpSchema, names []string, format string, enumNodes []*yaml.Node, fieldPaths []string) (string, *schema.ScalarType) {
-	var scalarName string
-	var scalarType *schema.ScalarType
-
-	switch names[0] {
-	case "boolean":
-		scalarName = string(rest.ScalarBoolean)
-		scalarType = defaultScalarTypes[rest.ScalarBoolean]
-	case "integer":
-		switch format {
-		case "unix-time":
-			scalarName = string(rest.ScalarUnixTime)
-			scalarType = defaultScalarTypes[rest.ScalarUnixTime]
-		case "int64":
-			scalarName = string(rest.ScalarInt64)
-			scalarType = defaultScalarTypes[rest.ScalarInt64]
-		default:
-			scalarName = string(rest.ScalarInt32)
-			scalarType = defaultScalarTypes[rest.ScalarInt32]
-		}
-	case "long":
-		scalarName = string(rest.ScalarInt64)
-		scalarType = defaultScalarTypes[rest.ScalarInt64]
-	case "number":
-		switch format {
-		case "float":
-			scalarName = string(rest.ScalarFloat32)
-			scalarType = defaultScalarTypes[rest.ScalarFloat32]
-		default:
-			scalarName = string(rest.ScalarFloat64)
-			scalarType = defaultScalarTypes[rest.ScalarFloat64]
-		}
-	case "file":
-		scalarName = string(rest.ScalarBinary)
-		scalarType = defaultScalarTypes[rest.ScalarBinary]
-	case "string":
-		if len(enumNodes) > 0 {
-			return buildEnumScalar(sm, enumNodes, fieldPaths)
-		}
-
-		switch format {
-		case "date":
-			scalarName = string(rest.ScalarDate)
-			scalarType = defaultScalarTypes[rest.ScalarDate]
-		case "date-time":
-			scalarName = string(rest.ScalarTimestampTZ)
-			scalarType = defaultScalarTypes[rest.ScalarTimestampTZ]
-		case "byte", "base64":
-			scalarName = string(rest.ScalarBytes)
-			scalarType = defaultScalarTypes[rest.ScalarBytes]
-		case "binary":
-			scalarName = string(rest.ScalarBinary)
-			scalarType = defaultScalarTypes[rest.ScalarBinary]
-		case "uuid":
-			scalarName = string(rest.ScalarUUID)
-			scalarType = defaultScalarTypes[rest.ScalarUUID]
-		case "uri":
-			scalarName = string(rest.ScalarURI)
-			scalarType = defaultScalarTypes[rest.ScalarURI]
-		case "ipv4":
-			scalarName = string(rest.ScalarIPV4)
-			scalarType = defaultScalarTypes[rest.ScalarIPV4]
-		case "ipv6":
-			scalarName = string(rest.ScalarIPV6)
-			scalarType = defaultScalarTypes[rest.ScalarIPV6]
-		default:
-			scalarName = string(rest.ScalarString)
-			scalarType = defaultScalarTypes[rest.ScalarString]
-		}
-	default:
-		scalarName = string(rest.ScalarJSON)
-		scalarType = defaultScalarTypes[rest.ScalarJSON]
-	}
-
-	return scalarName, scalarType
-}
-
-func canSetEnumToSchema(sm *rest.NDCHttpSchema, scalarName string, enums []string) bool {
-	existedScalar, ok := sm.ScalarTypes[scalarName]
-	if !ok {
-		return true
-	}
-
-	existedEnum, err := existedScalar.Representation.AsEnum()
-	if err == nil && utils.SliceUnorderedEqual(enums, existedEnum.OneOf) {
-		return true
-	}
-
-	return false
-}
-
-// remove nullable types from raw OpenAPI types
-func evaluateOpenAPITypes(input []string) []string {
-	var typeNames []string
-	for _, t := range input {
-		if t != "null" {
-			typeNames = append(typeNames, t)
-		}
-	}
-
-	return typeNames
-}
-
-func createSchemaFromOpenAPISchema(input *base.Schema) *rest.TypeSchema {
-	ps := &rest.TypeSchema{
-		Type: []string{},
-	}
-	if input == nil {
-		return ps
-	}
-	ps.Type = evaluateOpenAPITypes(input.Type)
-	ps.Format = input.Format
-	ps.Pattern = utils.RemoveYAMLSpecialCharacters([]byte(input.Pattern))
-	ps.Maximum = input.Maximum
-	ps.Minimum = input.Minimum
-	ps.MaxLength = input.MaxLength
-	ps.MinLength = input.MinLength
-	ps.Description = utils.StripHTMLTags(input.Description)
-	ps.ReadOnly = input.ReadOnly != nil && *input.ReadOnly
-	ps.WriteOnly = input.WriteOnly != nil && *input.WriteOnly
-
-	if input.XML != nil {
-		ps.XML = &rest.XMLSchema{
-			Name:      input.XML.Name,
-			Prefix:    input.XML.Prefix,
-			Namespace: input.XML.Namespace,
-			Wrapped:   input.XML.Wrapped,
-			Attribute: input.XML.Attribute,
-		}
-	}
-
-	return ps
 }
 
 // getMethodAlias merge method alias map with default value
@@ -290,17 +82,6 @@ func convertSecurity(security *base.SecurityRequirement) rest.AuthSecurity {
 	return results
 }
 
-// check if the OAS type is a scalar
-func isPrimitiveScalar(names []string) bool {
-	for _, name := range names {
-		if !slices.Contains([]string{"boolean", "integer", "number", "string", "file", "long", "null"}, name) {
-			return false
-		}
-	}
-
-	return true
-}
-
 // get the inner named type of the type encoder
 func getNamedType(typeSchema schema.TypeEncoder, recursive bool, defaultValue string) string {
 	switch ty := typeSchema.(type) {
@@ -323,73 +104,6 @@ func isNullableType(input schema.TypeEncoder) bool {
 	_, ok := input.(*schema.NullableType)
 
 	return ok
-}
-
-// Find common fields in all objects to merge the type.
-// If they have the same type, we don't need to wrap it with the nullable type.
-func mergeUnionObjects(httpSchema *rest.NDCHttpSchema, dest *rest.ObjectType, srcObjects []rest.ObjectType, unionType oasUnionType, fieldPaths []string) {
-	mergedObjectFields := make(map[string][]rest.ObjectField)
-	for _, object := range srcObjects {
-		for key, field := range object.Fields {
-			mergedObjectFields[key] = append(mergedObjectFields[key], field)
-		}
-	}
-
-	for key, fields := range mergedObjectFields {
-		if len(fields) == 1 {
-			newField := rest.ObjectField{
-				ObjectField: schema.ObjectField{
-					Description: fields[0].Description,
-					Arguments:   fields[0].Arguments,
-					Type:        fields[0].Type,
-				},
-				HTTP: fields[0].HTTP,
-			}
-
-			if unionType != oasAllOf && !isNullableType(newField.Type.Interface()) {
-				newField.Type = (schema.NullableType{
-					Type:           schema.TypeNullable,
-					UnderlyingType: newField.Type,
-				}).Encode()
-			}
-
-			dest.Fields[key] = newField
-
-			continue
-		}
-
-		var unionField rest.ObjectField
-		for i, field := range fields {
-			if i == 0 {
-				unionField = field
-
-				continue
-			}
-
-			unionType, ok := mergeUnionTypes(httpSchema, field.Type, unionField.Type, append(fieldPaths, key))
-			unionField.Type = unionType.Encode()
-			if !ok {
-				break
-			}
-
-			if unionField.Description == nil && field.Description != nil {
-				unionField.Description = field.Description
-			}
-
-			if unionField.HTTP == nil && field.HTTP != nil {
-				unionField.HTTP = field.HTTP
-			}
-		}
-
-		if len(fields) < len(srcObjects) && unionType != oasAllOf && !isNullableType(unionField.Type.Interface()) {
-			unionField.Type = (schema.NullableType{
-				Type:           schema.TypeNullable,
-				UnderlyingType: unionField.Type,
-			}).Encode()
-		}
-
-		dest.Fields[key] = unionField
-	}
 }
 
 func unwrapNullableUnionTypeSchemas(inputs []SchemaInfoCache) ([]SchemaInfoCache, bool, bool) {
@@ -694,48 +408,6 @@ func encodeHeaderArgumentName(name string) string {
 	return "header" + utils.ToPascalCase(name)
 }
 
-// evaluate and filter invalid types in allOf, anyOf or oneOf schemas
-func evalSchemaProxiesSlice(schemaProxies []*base.SchemaProxy, location rest.ParameterLocation) ([]*base.SchemaProxy, *base.Schema, bool) {
-	var results []*base.SchemaProxy
-	var typeNames []string
-	nullable := false
-	for _, proxy := range schemaProxies {
-		if proxy == nil {
-			continue
-		}
-		sc := proxy.Schema()
-		if sc == nil || (len(sc.Type) == 0 && len(sc.AllOf) == 0 && len(sc.AnyOf) == 0 && len(sc.OneOf) == 0) {
-			continue
-		}
-
-		// empty string enum is considered as nullable, e.g. key1=&key2=
-		// however, it's redundant and prevents the tool converting correct types
-		if (len(sc.Type) == 1 && sc.Type[0] == "null") ||
-			(location == rest.InQuery && (sc.Type[0] == "string" && len(sc.Enum) == 1 && (sc.Enum[0] == nil || sc.Enum[0].Value == ""))) {
-			nullable = true
-
-			continue
-		}
-
-		results = append(results, proxy)
-		if len(sc.Type) == 0 {
-			typeNames = append(typeNames, "any")
-		} else if !slices.Contains(typeNames, sc.Type[0]) {
-			typeNames = append(typeNames, sc.Type[0])
-		}
-	}
-
-	if len(typeNames) == 1 && len(results) > 1 && typeNames[0] == "string" {
-		// if the anyOf array contains both string and enum
-		// we can cast them to string
-		return nil, &base.Schema{
-			Type: typeNames,
-		}, nullable
-	}
-
-	return results, nil, nullable
-}
-
 func formatWriteObjectName(name string) string {
 	return name + "Input"
 }
@@ -790,23 +462,6 @@ func buildUniqueOperationName(httpSchema *rest.NDCHttpSchema, operationId, pathK
 	}
 
 	return opName
-}
-
-// guess the result type from content type
-func getResultTypeFromContentType(httpSchema *rest.NDCHttpSchema, contentType string) schema.TypeEncoder {
-	var scalarName rest.ScalarName
-	switch {
-	case strings.HasPrefix(contentType, "text/"):
-		scalarName = rest.ScalarString
-	case contentType == rest.ContentTypeOctetStream || strings.HasPrefix(contentType, "image/") || strings.HasPrefix(contentType, "video/"):
-		scalarName = rest.ScalarBinary
-	default:
-		scalarName = rest.ScalarJSON
-	}
-
-	httpSchema.AddScalar(string(scalarName), *defaultScalarTypes[scalarName])
-
-	return schema.NewNamedType(string(scalarName))
 }
 
 // check if the XML object doesn't have any child element.
@@ -916,14 +571,78 @@ func evalOperationPath(httpSchema *rest.NDCHttpSchema, rawPath string, arguments
 	return pathURL.Path + queryString + fragment, arguments, nil
 }
 
-func guessScalarResultTypeFromContentType(contentType string) rest.ScalarName {
-	ct := strings.TrimSpace(strings.Split(contentType, ";")[0])
-	switch {
-	case utils.IsContentTypeJSON(ct) || utils.IsContentTypeXML(ct) || ct == rest.ContentTypeNdJSON:
-		return rest.ScalarJSON
-	case utils.IsContentTypeText(ct):
-		return rest.ScalarString
+func transformNullableObjectProperties(httpSchema *rest.NDCHttpSchema, input schema.Type, newName string) (schema.TypeEncoder, bool) {
+	switch t := input.Interface().(type) {
+	case *schema.NullableType:
+		result, isObject := transformNullableObjectProperties(httpSchema, t.UnderlyingType, newName)
+
+		return schema.NewNullableType(result), isObject
+	case *schema.ArrayType:
+		result, isObject := transformNullableObjectProperties(httpSchema, t.ElementType, newName)
+
+		return schema.NewArrayType(result), isObject
+	case *schema.NamedType:
+		if _, ok := httpSchema.ScalarTypes[t.Name]; ok {
+			return t, false
+		}
+
+		objType, ok := httpSchema.ObjectTypes[t.Name]
+		if !ok {
+			return t, false
+		}
+
+		newObjectType := rest.ObjectType{
+			Description: objType.Description,
+			Fields:      make(map[string]rest.ObjectField),
+			XML:         objType.XML,
+		}
+
+		for key, field := range objType.Fields {
+			fieldType := field.Type.Interface()
+			if !isNullableType(fieldType) {
+				field.Type = schema.NewNullableType(fieldType).Encode()
+			}
+			newObjectType.Fields[key] = field
+		}
+
+		httpSchema.ObjectTypes[newName] = newObjectType
+
+		return schema.NewNamedType(newName), true
 	default:
-		return rest.ScalarBinary
+		return t, false
+	}
+}
+
+func transformNullableObjectPropertiesSchema(httpSchema *rest.NDCHttpSchema, result *SchemaInfoCache, nullable bool, fieldPaths []string) *SchemaInfoCache {
+	readSchemaName := utils.StringSliceToPascalCase(fieldPaths)
+	writeSchemaName := formatWriteObjectName(readSchemaName)
+
+	var ok bool
+	result.TypeRead, ok = transformNullableObjectProperties(httpSchema, result.TypeRead.Encode(), readSchemaName)
+	if !ok {
+		return createSchemaInfoJSONScalar(httpSchema, nullable)
+	}
+
+	result.TypeWrite, ok = transformNullableObjectProperties(httpSchema, result.TypeWrite.Encode(), writeSchemaName)
+	if !ok {
+		return createSchemaInfoJSONScalar(httpSchema, nullable)
+	}
+
+	return result
+}
+
+func createSchemaInfoJSONScalar(httpSchema *rest.NDCHttpSchema, nullable bool) *SchemaInfoCache {
+	scalarName := rest.ScalarJSON
+	var result schema.TypeEncoder = schema.NewNamedType(string(scalarName))
+	if nullable {
+		result = schema.NewNullableType(result)
+	}
+
+	httpSchema.AddScalar(string(scalarName), *defaultScalarTypes[scalarName])
+
+	return &SchemaInfoCache{
+		TypeRead:   result,
+		TypeWrite:  result,
+		TypeSchema: &rest.TypeSchema{},
 	}
 }

--- a/ndc-http-schema/openapi/internal/utils.go
+++ b/ndc-http-schema/openapi/internal/utils.go
@@ -55,9 +55,7 @@ func getSchemaRefTypeNameV3(name string) string {
 	return result[1]
 }
 
-func getScalarFromType(sm *rest.NDCHttpSchema, names []string, format string, enumNodes []*yaml.Node, apiPath string, fieldPaths []string) (string, bool) {
-	var scalarName string
-	var scalarType *schema.ScalarType
+func extractNullableFromOASTypes(names []string) ([]string, bool) {
 	var typeNames []string
 	var nullable bool
 
@@ -69,7 +67,14 @@ func getScalarFromType(sm *rest.NDCHttpSchema, names []string, format string, en
 		}
 	}
 
-	if len(typeNames) != 1 {
+	return typeNames, nullable
+}
+
+func getScalarFromType(sm *rest.NDCHttpSchema, names []string, format string, enumNodes []*yaml.Node, apiPath string, fieldPaths []string) string {
+	var scalarName string
+	var scalarType *schema.ScalarType
+
+	if len(names) != 1 {
 		scalarName = "JSON"
 		scalarType = defaultScalarTypes[rest.ScalarJSON]
 	} else {
@@ -80,7 +85,7 @@ func getScalarFromType(sm *rest.NDCHttpSchema, names []string, format string, en
 		sm.ScalarTypes[scalarName] = *scalarType
 	}
 
-	return scalarName, nullable
+	return scalarName
 }
 
 func getScalarFromNamedType(sm *rest.NDCHttpSchema, names []string, format string, enumNodes []*yaml.Node, apiPath string, fieldPaths []string) (string, *schema.ScalarType) {

--- a/ndc-http-schema/openapi/internal/utils.go
+++ b/ndc-http-schema/openapi/internal/utils.go
@@ -380,6 +380,7 @@ func mergeUnionTypes(httpSchema *rest.NDCHttpSchema, a schema.Type, b schema.Typ
 		case slices.Contains(floatTypeRepresentations, typeRepA) && slices.Contains(floatTypeRepresentations, typeRepB):
 			scalarName = rest.ScalarFloat64
 			isMatched = true
+		// use boolean if the union type if oneOf boolean or enum (true, false)
 		case (enumA != nil && len(enumA.OneOf) == 2 && slices.Contains(enumA.OneOf, "true") && slices.Contains(enumA.OneOf, "false") && typeRepB == schema.TypeRepresentationTypeBoolean) ||
 			(enumB != nil && len(enumB.OneOf) == 2 && slices.Contains(enumB.OneOf, "true") && slices.Contains(enumB.OneOf, "false") && typeRepA == schema.TypeRepresentationTypeBoolean):
 			scalarName = rest.ScalarBoolean

--- a/ndc-http-schema/openapi/internal/utils.go
+++ b/ndc-http-schema/openapi/internal/utils.go
@@ -574,7 +574,8 @@ func evalSchemaProxiesSlice(schemaProxies []*base.SchemaProxy, location rest.Par
 
 		// empty string enum is considered as nullable, e.g. key1=&key2=
 		// however, it's redundant and prevents the tool converting correct types
-		if location == rest.InQuery && (sc.Type[0] == "string" && len(sc.Enum) == 1 && (sc.Enum[0] == nil || sc.Enum[0].Value == "")) {
+		if (len(sc.Type) == 1 && sc.Type[0] == "null") ||
+			(location == rest.InQuery && (sc.Type[0] == "string" && len(sc.Enum) == 1 && (sc.Enum[0] == nil || sc.Enum[0].Value == ""))) {
 			nullable = true
 
 			continue

--- a/ndc-http-schema/openapi/oas2_test.go
+++ b/ndc-http-schema/openapi/oas2_test.go
@@ -86,7 +86,12 @@ func TestOpenAPIv2ToRESTSchema(t *testing.T) {
 				t.FailNow()
 			}
 
-			assertRESTSchemaEqual(t, &expected, output)
+			bs, err := json.Marshal(output)
+			assert.NilError(t, err)
+
+			var result rest.NDCHttpSchema
+			assert.NilError(t, json.Unmarshal(bs, &result))
+			assertRESTSchemaEqual(t, &expected, &result)
 			assertConnectorSchema(t, tc.Schema, output)
 		})
 	}

--- a/ndc-http-schema/openapi/testdata/onesignal/expected.json
+++ b/ndc-http-schema/openapi/testdata/onesignal/expected.json
@@ -569,8 +569,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "JSON",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "JSON",
+                "type": "named"
+              }
             }
           },
           "http": {
@@ -584,8 +587,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "JSON",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "JSON",
+                "type": "named"
+              }
             }
           },
           "http": {

--- a/ndc-http-schema/openapi/testdata/onesignal/expected.json
+++ b/ndc-http-schema/openapi/testdata/onesignal/expected.json
@@ -1409,7 +1409,15 @@
             "type": "named"
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ],
+              "xml": {
+                "name": "Notification"
+              }
+            }
           }
         }
       },
@@ -1491,7 +1499,12 @@
             "type": "named"
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ]
+            }
           }
         },
         "notification_id": {

--- a/ndc-http-schema/openapi/testdata/onesignal/expected.json
+++ b/ndc-http-schema/openapi/testdata/onesignal/expected.json
@@ -505,7 +505,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "NotificationsEvents",
+              "name": "GetNotificationHistoryBodyEvents",
               "type": "named"
             }
           },
@@ -1556,6 +1556,17 @@
         "type": "enum"
       }
     },
+    "GetNotificationHistoryBodyEvents": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "sent",
+          "clicked"
+        ],
+        "type": "enum"
+      }
+    },
     "Int32": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -1582,17 +1593,6 @@
       "comparison_operators": {},
       "representation": {
         "type": "json"
-      }
-    },
-    "NotificationsEvents": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "sent",
-          "clicked"
-        ],
-        "type": "enum"
       }
     },
     "OutcomeDataAggregation": {

--- a/ndc-http-schema/openapi/testdata/onesignal/expected.json
+++ b/ndc-http-schema/openapi/testdata/onesignal/expected.json
@@ -206,7 +206,6 @@
             }
           },
           "http": {
-            "type": [],
             "xml": {
               "name": "Notification200Errors"
             }
@@ -843,7 +842,7 @@
           }
         },
         "converted": {
-          "description": "Number of users who have clicked / tapped on your notification.",
+          "description": "Number of messages that were clicked.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -858,7 +857,7 @@
           }
         },
         "errored": {
-          "description": "Number of notifications that could not be delivered due to an error. You can find more information by viewing the notification in the dashboard.",
+          "description": "Number of errors reported.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -895,7 +894,7 @@
           }
         },
         "failed": {
-          "description": "Number of notifications that could not be delivered due to those devices being unsubscribed.",
+          "description": "Number of messages sent to unsubscribed devices.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -1035,7 +1034,7 @@
           }
         },
         "received": {
-          "description": "Confirmed Deliveries number of devices that received the push notification. Paid Feature Only. Free accounts will see 0.",
+          "description": "Number of devices that received the message.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -1095,7 +1094,7 @@
           }
         },
         "successful": {
-          "description": "Number of notifications that were successfully delivered.",
+          "description": "Number of messages delivered to push servers, mobile carriers, or email service providers.",
           "type": {
             "type": "nullable",
             "underlying_type": {

--- a/ndc-http-schema/openapi/testdata/onesignal/schema.json
+++ b/ndc-http-schema/openapi/testdata/onesignal/schema.json
@@ -338,8 +338,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "JSON",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "JSON",
+                "type": "named"
+              }
             }
           }
         },
@@ -348,8 +351,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "JSON",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "JSON",
+                "type": "named"
+              }
             }
           }
         },

--- a/ndc-http-schema/openapi/testdata/onesignal/schema.json
+++ b/ndc-http-schema/openapi/testdata/onesignal/schema.json
@@ -507,7 +507,7 @@
           }
         },
         "converted": {
-          "description": "Number of users who have clicked / tapped on your notification.",
+          "description": "Number of messages that were clicked.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -517,7 +517,7 @@
           }
         },
         "errored": {
-          "description": "Number of notifications that could not be delivered due to an error. You can find more information by viewing the notification in the dashboard.",
+          "description": "Number of errors reported.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -539,7 +539,7 @@
           }
         },
         "failed": {
-          "description": "Number of notifications that could not be delivered due to those devices being unsubscribed.",
+          "description": "Number of messages sent to unsubscribed devices.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -623,7 +623,7 @@
           }
         },
         "received": {
-          "description": "Confirmed Deliveries number of devices that received the push notification. Paid Feature Only. Free accounts will see 0.",
+          "description": "Number of devices that received the message.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -662,7 +662,7 @@
           }
         },
         "successful": {
-          "description": "Number of notifications that were successfully delivered.",
+          "description": "Number of messages delivered to push servers, mobile carriers, or email service providers.",
           "type": {
             "type": "nullable",
             "underlying_type": {

--- a/ndc-http-schema/openapi/testdata/onesignal/schema.json
+++ b/ndc-http-schema/openapi/testdata/onesignal/schema.json
@@ -294,7 +294,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "NotificationsEvents",
+              "name": "GetNotificationHistoryBodyEvents",
               "type": "named"
             }
           }
@@ -934,6 +934,17 @@
         "type": "enum"
       }
     },
+    "GetNotificationHistoryBodyEvents": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "sent",
+          "clicked"
+        ],
+        "type": "enum"
+      }
+    },
     "Int32": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -960,17 +971,6 @@
       "comparison_operators": {},
       "representation": {
         "type": "json"
-      }
-    },
-    "NotificationsEvents": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "sent",
-          "clicked"
-        ],
-        "type": "enum"
       }
     },
     "OutcomeDataAggregation": {

--- a/ndc-http-schema/openapi/testdata/openai/expected.json
+++ b/ndc-http-schema/openapi/testdata/openai/expected.json
@@ -1744,7 +1744,15 @@
             "type": "named"
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ],
+              "xml": {
+                "name": "CreateModelRequest"
+              }
+            }
           }
         }
       },
@@ -1776,7 +1784,15 @@
             "type": "named"
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ],
+              "xml": {
+                "name": "CreateChatCompletionRequest"
+              }
+            }
           }
         }
       },
@@ -1805,7 +1821,15 @@
             "type": "named"
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ],
+              "xml": {
+                "name": "CreateThreadAndRunRequest"
+              }
+            }
           }
         }
       },

--- a/ndc-http-schema/openapi/testdata/openai/expected.json
+++ b/ndc-http-schema/openapi/testdata/openai/expected.json
@@ -266,8 +266,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "ChatCompletionRequestAssistantMessageFunctionCallInput",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "ChatCompletionRequestAssistantMessageFunctionCallInput",
+                "type": "named"
+              }
             }
           },
           "http": {
@@ -884,8 +887,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "ChatCompletionStreamOptionsInput",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "ChatCompletionStreamOptionsInput",
+                "type": "named"
+              }
             }
           },
           "http": {
@@ -1161,8 +1167,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CreateChatCompletionResponseChoicesLogprobs",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "CreateChatCompletionResponseChoicesLogprobs",
+                "type": "named"
+              }
             }
           },
           "http": {
@@ -1275,8 +1284,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CreateThreadRequestToolResourcesInput",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "CreateThreadRequestToolResourcesInput",
+                "type": "named"
+              }
             }
           },
           "http": {

--- a/ndc-http-schema/openapi/testdata/openai/expected.json
+++ b/ndc-http-schema/openapi/testdata/openai/expected.json
@@ -253,12 +253,18 @@
     "ChatCompletionRequestMessageInput": {
       "fields": {
         "content": {
+          "description": "The contents of the system message.",
           "type": {
             "type": "nullable",
             "underlying_type": {
               "name": "JSON",
               "type": "named"
             }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
           }
         },
         "function_call": {
@@ -280,7 +286,7 @@
           }
         },
         "name": {
-          "description": "The name of the function to call.",
+          "description": "An optional name for the participant. Provides the model information to differentiate between participants of the same role.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -295,7 +301,7 @@
           }
         },
         "role": {
-          "description": "The role of the messages author, in this case `function`.",
+          "description": "The role of the messages author, in this case `system`.",
           "type": {
             "name": "ChatCompletionRequestMessageRoleEnum",
             "type": "named"
@@ -645,9 +651,7 @@
               "type": "named"
             }
           },
-          "http": {
-            "type": []
-          }
+          "http": {}
         },
         "functions": {
           "description": "Deprecated in favor of `tools`.  A list of functions the model may generate JSON inputs for.",
@@ -863,9 +867,7 @@
               "type": "named"
             }
           },
-          "http": {
-            "type": []
-          }
+          "http": {}
         },
         "stream": {
           "description": "If set, partial message deltas will be sent, like in ChatGPT. Tokens will be sent as data-only [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format) as they become available, with the stream terminated by a `data: [DONE]` message. [Example Python code](https://cookbook.openai.com/examples/how_to_stream_completions).",
@@ -930,7 +932,6 @@
             }
           },
           "http": {
-            "type": [],
             "xml": {
               "name": "ChatCompletionToolChoiceOption"
             }
@@ -1424,7 +1425,7 @@
           }
         },
         "type": {
-          "description": "Always `static`.",
+          "description": "Always `auto`.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -1443,7 +1444,6 @@
     "CreateThreadRequestToolResourcesFileSearchVectorStoresInput": {
       "fields": {
         "chunking_strategy": {
-          "description": "The chunking strategy used to chunk the file(s). If not set, will use the `auto` strategy.",
           "type": {
             "type": "nullable",
             "underlying_type": {

--- a/ndc-http-schema/openapi/testdata/openai/schema.json
+++ b/ndc-http-schema/openapi/testdata/openai/schema.json
@@ -156,8 +156,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "ChatCompletionRequestAssistantMessageFunctionCallInput",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "ChatCompletionRequestAssistantMessageFunctionCallInput",
+                "type": "named"
+              }
             }
           }
         },
@@ -538,8 +541,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "ChatCompletionStreamOptionsInput",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "ChatCompletionStreamOptionsInput",
+                "type": "named"
+              }
             }
           }
         },
@@ -707,8 +713,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CreateChatCompletionResponseChoicesLogprobs",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "CreateChatCompletionResponseChoicesLogprobs",
+                "type": "named"
+              }
             }
           }
         },
@@ -780,8 +789,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CreateThreadRequestToolResourcesInput",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "CreateThreadRequestToolResourcesInput",
+                "type": "named"
+              }
             }
           }
         }

--- a/ndc-http-schema/openapi/testdata/openai/schema.json
+++ b/ndc-http-schema/openapi/testdata/openai/schema.json
@@ -143,6 +143,7 @@
     "ChatCompletionRequestMessageInput": {
       "fields": {
         "content": {
+          "description": "The contents of the system message.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -165,7 +166,7 @@
           }
         },
         "name": {
-          "description": "The name of the function to call.",
+          "description": "An optional name for the participant. Provides the model information to differentiate between participants of the same role.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -175,7 +176,7 @@
           }
         },
         "role": {
-          "description": "The role of the messages author, in this case `function`.",
+          "description": "The role of the messages author, in this case `system`.",
           "type": {
             "name": "ChatCompletionRequestMessageRoleEnum",
             "type": "named"
@@ -877,7 +878,7 @@
           }
         },
         "type": {
-          "description": "Always `static`.",
+          "description": "Always `auto`.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -891,7 +892,6 @@
     "CreateThreadRequestToolResourcesFileSearchVectorStoresInput": {
       "fields": {
         "chunking_strategy": {
-          "description": "The chunking strategy used to chunk the file(s). If not set, will use the `auto` strategy.",
           "type": {
             "type": "nullable",
             "underlying_type": {

--- a/ndc-http-schema/openapi/testdata/petstore2/expected.json
+++ b/ndc-http-schema/openapi/testdata/petstore2/expected.json
@@ -3043,6 +3043,7 @@
       },
       "arguments": {
         "body": {
+          "description": "Request body of POST /oauth2/register",
           "type": {
             "name": "OAuth2ClientInput",
             "type": "named"

--- a/ndc-http-schema/openapi/testdata/petstore2/expected.json
+++ b/ndc-http-schema/openapi/testdata/petstore2/expected.json
@@ -66,7 +66,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "BrowsersEnum",
+              "name": "GETBrowsersStats",
               "type": "named"
             }
           },
@@ -3379,18 +3379,6 @@
         "type": "boolean"
       }
     },
-    "BrowsersEnum": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "day",
-          "week",
-          "month"
-        ],
-        "type": "enum"
-      }
-    },
     "ContactdbCustomFieldType": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -3408,6 +3396,18 @@
       "comparison_operators": {},
       "representation": {
         "type": "float64"
+      }
+    },
+    "GETBrowsersStats": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "day",
+          "week",
+          "month"
+        ],
+        "type": "enum"
       }
     },
     "Int32": {

--- a/ndc-http-schema/openapi/testdata/petstore2/expected.json
+++ b/ndc-http-schema/openapi/testdata/petstore2/expected.json
@@ -693,9 +693,7 @@
           "http": {
             "name": "start_date",
             "in": "query",
-            "schema": {
-              "type": null
-            }
+            "schema": {}
           }
         }
       },
@@ -1208,9 +1206,7 @@
             "type": [
               "array"
             ],
-            "items": {
-              "type": null
-            }
+            "items": {}
           }
         },
         "legacy": {
@@ -1741,7 +1737,6 @@
     "GETGeoStatsResultStats": {
       "fields": {
         "metrics": {
-          "description": "The individual events and their stats.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -2179,9 +2174,7 @@
               "type": "named"
             }
           },
-          "http": {
-            "type": null
-          }
+          "http": {}
         },
         "id": {
           "type": {
@@ -2310,9 +2303,7 @@
               "type": "named"
             }
           },
-          "http": {
-            "type": null
-          }
+          "http": {}
         },
         "id": {
           "type": {
@@ -2423,9 +2414,7 @@
               "type": "named"
             }
           },
-          "http": {
-            "type": null
-          }
+          "http": {}
         },
         "id": {
           "type": {

--- a/ndc-http-schema/openapi/testdata/petstore2/schema.json
+++ b/ndc-http-schema/openapi/testdata/petstore2/schema.json
@@ -1727,6 +1727,7 @@
     {
       "arguments": {
         "body": {
+          "description": "Request body of POST /oauth2/register",
           "type": {
             "name": "OAuth2ClientInput",
             "type": "named"

--- a/ndc-http-schema/openapi/testdata/petstore2/schema.json
+++ b/ndc-http-schema/openapi/testdata/petstore2/schema.json
@@ -8,7 +8,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "BrowsersEnum",
+              "name": "GETBrowsersStats",
               "type": "named"
             }
           }
@@ -1880,18 +1880,6 @@
         "type": "boolean"
       }
     },
-    "BrowsersEnum": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "day",
-          "week",
-          "month"
-        ],
-        "type": "enum"
-      }
-    },
     "ContactdbCustomFieldType": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -1909,6 +1897,18 @@
       "comparison_operators": {},
       "representation": {
         "type": "float64"
+      }
+    },
+    "GETBrowsersStats": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "day",
+          "week",
+          "month"
+        ],
+        "type": "enum"
       }
     },
     "Int32": {

--- a/ndc-http-schema/openapi/testdata/petstore2/schema.json
+++ b/ndc-http-schema/openapi/testdata/petstore2/schema.json
@@ -964,7 +964,6 @@
     "GETGeoStatsResultStats": {
       "fields": {
         "metrics": {
-          "description": "The individual events and their stats.",
           "type": {
             "type": "nullable",
             "underlying_type": {

--- a/ndc-http-schema/openapi/testdata/petstore3/expected.json
+++ b/ndc-http-schema/openapi/testdata/petstore3/expected.json
@@ -8190,7 +8190,12 @@
             }
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ]
+            }
           }
         }
       },
@@ -8229,7 +8234,12 @@
             "type": "named"
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ]
+            }
           }
         }
       },
@@ -8343,7 +8353,12 @@
             }
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ]
+            }
           }
         }
       },
@@ -8408,7 +8423,12 @@
             "type": "named"
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ]
+            }
           }
         },
         "headerXRateLimitLimit": {
@@ -8465,7 +8485,12 @@
             }
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ]
+            }
           }
         },
         "id": {
@@ -8519,7 +8544,15 @@
             "type": "named"
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ],
+              "xml": {
+                "name": "pet"
+              }
+            }
           }
         }
       },
@@ -8563,7 +8596,15 @@
             "type": "named"
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ],
+              "xml": {
+                "name": "CreateFineTuningJobRequest"
+              }
+            }
           }
         }
       },
@@ -8598,7 +8639,20 @@
             }
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "array"
+              ],
+              "items": {
+                "type": [
+                  "object"
+                ],
+                "xml": {
+                  "name": "user"
+                }
+              }
+            }
           }
         }
       },
@@ -8763,7 +8817,15 @@
             }
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ],
+              "xml": {
+                "name": "order"
+              }
+            }
           }
         }
       },
@@ -8795,7 +8857,17 @@
             }
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ],
+              "xml": {
+                "name": "book",
+                "prefix": "smp",
+                "namespace": "http://example.com/schema"
+              }
+            }
           }
         }
       },
@@ -8827,7 +8899,15 @@
             }
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ],
+              "xml": {
+                "name": "comments"
+              }
+            }
           }
         }
       },
@@ -8864,7 +8944,15 @@
             "type": "named"
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ],
+              "xml": {
+                "name": "pet"
+              }
+            }
           }
         }
       },
@@ -8901,7 +8989,15 @@
             "type": "named"
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ],
+              "xml": {
+                "name": "pet"
+              }
+            }
           }
         }
       },
@@ -9042,7 +9138,13 @@
             }
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "string"
+              ],
+              "format": "binary"
+            }
           }
         },
         "petId": {
@@ -9110,7 +9212,12 @@
             }
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ]
+            }
           }
         },
         "headerXRateLimitLimit": {

--- a/ndc-http-schema/openapi/testdata/petstore3/expected.json
+++ b/ndc-http-schema/openapi/testdata/petstore3/expected.json
@@ -759,6 +759,69 @@
     }
   },
   "object_types": {
+    "Address": {
+      "fields": {
+        "city": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "state": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "street": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "zip": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        }
+      },
+      "xml": {
+        "name": "address"
+      }
+    },
     "AddressInput": {
       "fields": {
         "city": {
@@ -1209,6 +1272,136 @@
             ]
           }
         }
+      }
+    },
+    "Customer": {
+      "fields": {
+        "address": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Address",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          },
+          "http": {
+            "type": [
+              "array"
+            ],
+            "items": {
+              "type": [
+                "object"
+              ],
+              "xml": {
+                "name": "address"
+              }
+            },
+            "xml": {
+              "name": "addresses",
+              "wrapped": true
+            }
+          }
+        },
+        "id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int64",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "integer"
+            ],
+            "format": "int64"
+          }
+        },
+        "username": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        }
+      },
+      "xml": {
+        "name": "customer"
+      }
+    },
+    "CustomerInput": {
+      "fields": {
+        "address": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "AddressInput",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          },
+          "http": {
+            "type": [
+              "array"
+            ],
+            "items": {
+              "type": [
+                "object"
+              ],
+              "xml": {
+                "name": "address"
+              }
+            },
+            "xml": {
+              "name": "addresses",
+              "wrapped": true
+            }
+          }
+        },
+        "id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int64",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "integer"
+            ],
+            "format": "int64"
+          }
+        },
+        "username": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        }
+      },
+      "xml": {
+        "name": "customer"
       }
     },
     "GetArchitecturesResult": {
@@ -1717,6 +1910,23 @@
             ]
           }
         },
+        "customer": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Customer",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "object"
+            ],
+            "xml": {
+              "name": "customer"
+            }
+          }
+        },
         "id": {
           "type": {
             "type": "nullable",
@@ -1811,6 +2021,23 @@
             "type": [
               "boolean"
             ]
+          }
+        },
+        "customer": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "CustomerInput",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "object"
+            ],
+            "xml": {
+              "name": "customer"
+            }
           }
         },
         "id": {

--- a/ndc-http-schema/openapi/testdata/petstore3/expected.json
+++ b/ndc-http-schema/openapi/testdata/petstore3/expected.json
@@ -76,7 +76,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "InvoicesCollectionMethod",
+              "name": "GetInvoicesCollectionMethod",
               "type": "named"
             }
           },
@@ -246,7 +246,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "InvoicesStatus",
+              "name": "GetInvoicesStatus",
               "type": "named"
             }
           },
@@ -330,7 +330,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "PetStatus",
+              "name": "FindPetsByStatusStatus",
               "type": "named"
             }
           },
@@ -582,7 +582,7 @@
         "in": {
           "description": "Where to search and apply a XPath expression: either the list of projects or the list of packages.  Example of a result when `projects` is selected: ```                                      x86_64                        x86_64                Standard OBS instance at build.opensuse.org     This instance delivers the default build targets for OBS.     https://api.opensuse.org/public     ```  Example of a result when `packages` is selected: ```                   ```",
           "type": {
-            "name": "SearchIn",
+            "name": "GetSearchXmlIn",
             "type": "named"
           },
           "http": {
@@ -1622,7 +1622,7 @@
         "object": {
           "description": "String representing the object's type. Objects of the same type share the same value. Always has the value `list`.",
           "type": {
-            "name": "InvoicesObject",
+            "name": "GetInvoicesResultObject",
             "type": "named"
           },
           "http": {
@@ -2563,7 +2563,7 @@
         },
         "type": {
           "type": {
-            "name": "CheckoutType",
+            "name": "PostCheckoutSessionsBodyAutomaticTaxLiabilityType",
             "type": "named"
           },
           "http": {
@@ -2595,7 +2595,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutPromotions",
+              "name": "PostCheckoutSessionsBodyConsentCollectionPromotions",
               "type": "named"
             }
           },
@@ -2609,7 +2609,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutTermsOfService",
+              "name": "PostCheckoutSessionsBodyConsentCollectionTermsOfService",
               "type": "named"
             }
           },
@@ -2625,7 +2625,7 @@
       "fields": {
         "position": {
           "type": {
-            "name": "CheckoutPosition",
+            "name": "PostCheckoutSessionsBodyConsentCollectionPaymentMethodReuseAgreementPosition",
             "type": "named"
           },
           "http": {
@@ -3004,7 +3004,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutAddress",
+              "name": "PostCheckoutSessionsBodyCustomerUpdateAddress",
               "type": "named"
             }
           },
@@ -3018,7 +3018,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutName",
+              "name": "PostCheckoutSessionsBodyCustomerUpdateName",
               "type": "named"
             }
           },
@@ -3032,7 +3032,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutShipping",
+              "name": "PostCheckoutSessionsBodyCustomerUpdateShipping",
               "type": "named"
             }
           },
@@ -3130,7 +3130,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutBillingAddressCollection",
+              "name": "PostCheckoutSessionsBodyBillingAddressCollection",
               "type": "named"
             }
           },
@@ -3261,7 +3261,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutCustomerCreation",
+              "name": "PostCheckoutSessionsBodyCustomerCreation",
               "type": "named"
             }
           },
@@ -3407,7 +3407,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutLocale",
+              "name": "PostCheckoutSessionsBodyLocale",
               "type": "named"
             }
           },
@@ -3437,7 +3437,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutMode",
+              "name": "PostCheckoutSessionsBodyMode",
               "type": "named"
             }
           },
@@ -3467,7 +3467,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutPaymentMethodCollection",
+              "name": "PostCheckoutSessionsBodyPaymentMethodCollection",
               "type": "named"
             }
           },
@@ -3514,7 +3514,7 @@
             "type": "nullable",
             "underlying_type": {
               "element_type": {
-                "name": "CheckoutPaymentMethodTypes",
+                "name": "PostCheckoutSessionsBodyPaymentMethodTypes",
                 "type": "named"
               },
               "type": "array"
@@ -3551,7 +3551,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutRedirectOnCompletion",
+              "name": "PostCheckoutSessionsBodyRedirectOnCompletion",
               "type": "named"
             }
           },
@@ -3635,7 +3635,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutSubmitType",
+              "name": "PostCheckoutSessionsBodySubmitType",
               "type": "named"
             }
           },
@@ -3696,7 +3696,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutUiMode",
+              "name": "PostCheckoutSessionsBodyUiMode",
               "type": "named"
             }
           },
@@ -3905,7 +3905,7 @@
         },
         "type": {
           "type": {
-            "name": "CheckoutType",
+            "name": "PostCheckoutSessionsBodyInvoiceCreationInvoiceDataIssuerType",
             "type": "named"
           },
           "http": {
@@ -3922,7 +3922,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutAmountTaxDisplay",
+              "name": "PostCheckoutSessionsBodyInvoiceCreationInvoiceDataRenderingOptionsAmountTaxDisplay",
               "type": "named"
             }
           },
@@ -4144,7 +4144,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutTaxBehavior",
+              "name": "PostCheckoutSessionsBodyLineItemsPriceDataTaxBehavior",
               "type": "named"
             }
           },
@@ -4271,7 +4271,7 @@
       "fields": {
         "interval": {
           "type": {
-            "name": "CheckoutInterval",
+            "name": "PostCheckoutSessionsBodyLineItemsPriceDataRecurringInterval",
             "type": "named"
           },
           "http": {
@@ -4317,7 +4317,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutCaptureMethod",
+              "name": "PostCheckoutSessionsBodyPaymentIntentDataCaptureMethod",
               "type": "named"
             }
           },
@@ -4388,7 +4388,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutSetupFutureUsage",
+              "name": "PostCheckoutSessionsBodyPaymentIntentDataSetupFutureUsage",
               "type": "named"
             }
           },
@@ -4687,7 +4687,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutCurrency",
+              "name": "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitCurrency",
               "type": "named"
             }
           },
@@ -4729,7 +4729,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutVerificationMethod",
+              "name": "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitVerificationMethod",
               "type": "named"
             }
           },
@@ -4762,7 +4762,7 @@
             "type": "nullable",
             "underlying_type": {
               "element_type": {
-                "name": "CheckoutDefaultFor",
+                "name": "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor",
                 "type": "named"
               },
               "type": "array"
@@ -4798,7 +4798,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutPaymentSchedule",
+              "name": "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule",
               "type": "named"
             }
           },
@@ -4812,7 +4812,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutTransactionType",
+              "name": "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitMandateOptionsTransactionType",
               "type": "named"
             }
           },
@@ -4984,7 +4984,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutRequestThreeDSecure",
+              "name": "PostCheckoutSessionsBodyPaymentMethodOptionsCardRequestThreeDSecure",
               "type": "named"
             }
           },
@@ -4998,7 +4998,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutSetupFutureUsage",
+              "name": "PostCheckoutSessionsBodyPaymentMethodOptionsCardSetupFutureUsage",
               "type": "named"
             }
           },
@@ -5113,7 +5113,7 @@
             "type": "nullable",
             "underlying_type": {
               "element_type": {
-                "name": "CheckoutRequestedAddressTypes",
+                "name": "PostCheckoutSessionsBodyPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes",
                 "type": "named"
               },
               "type": "array"
@@ -5163,7 +5163,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutFundingType",
+              "name": "PostCheckoutSessionsBodyPaymentMethodOptionsCustomerBalanceFundingType",
               "type": "named"
             }
           },
@@ -5874,7 +5874,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutPreferredLocale",
+              "name": "PostCheckoutSessionsBodyPaymentMethodOptionsPaypalPreferredLocale",
               "type": "named"
             }
           },
@@ -6028,7 +6028,7 @@
             "type": "nullable",
             "underlying_type": {
               "element_type": {
-                "name": "CheckoutPermissions",
+                "name": "PostCheckoutSessionsBodyPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions",
                 "type": "named"
               },
               "type": "array"
@@ -6051,7 +6051,7 @@
             "type": "nullable",
             "underlying_type": {
               "element_type": {
-                "name": "CheckoutPrefetch",
+                "name": "PostCheckoutSessionsBodyPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch",
                 "type": "named"
               },
               "type": "array"
@@ -6135,7 +6135,7 @@
         },
         "client": {
           "type": {
-            "name": "CheckoutClient",
+            "name": "PostCheckoutSessionsBodyPaymentMethodOptionsWechatPayClient",
             "type": "named"
           },
           "http": {
@@ -6230,7 +6230,7 @@
         "allowed_countries": {
           "type": {
             "element_type": {
-              "name": "CheckoutAllowedCountries",
+              "name": "PostCheckoutSessionsBodyShippingAddressCollectionAllowedCountries",
               "type": "named"
             },
             "type": "array"
@@ -6317,7 +6317,7 @@
       "fields": {
         "unit": {
           "type": {
-            "name": "CheckoutUnit",
+            "name": "PostCheckoutSessionsBodyShippingOptionsShippingRateDataDeliveryEstimateMaximumUnit",
             "type": "named"
           },
           "http": {
@@ -6343,7 +6343,7 @@
       "fields": {
         "unit": {
           "type": {
-            "name": "CheckoutUnit",
+            "name": "PostCheckoutSessionsBodyShippingOptionsShippingRateDataDeliveryEstimateMinimumUnit",
             "type": "named"
           },
           "http": {
@@ -6465,7 +6465,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutTaxBehavior",
+              "name": "PostCheckoutSessionsBodyShippingOptionsShippingRateDataTaxBehavior",
               "type": "named"
             }
           },
@@ -6621,7 +6621,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutProrationBehavior",
+              "name": "PostCheckoutSessionsBodySubscriptionDataProrationBehavior",
               "type": "named"
             }
           },
@@ -6726,7 +6726,7 @@
         },
         "type": {
           "type": {
-            "name": "CheckoutType",
+            "name": "PostCheckoutSessionsBodySubscriptionDataInvoiceSettingsIssuerType",
             "type": "named"
           },
           "http": {
@@ -6770,7 +6770,7 @@
       "fields": {
         "missing_payment_method": {
           "type": {
-            "name": "CheckoutMissingPaymentMethod",
+            "name": "PostCheckoutSessionsBodySubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod",
             "type": "named"
           },
           "http": {
@@ -6935,7 +6935,7 @@
         "purpose": {
           "description": "The [purpose](https://stripe.com/docs/file-upload#uploading-a-file) of the uploaded file.",
           "type": {
-            "name": "FilesPurpose",
+            "name": "PostFilesBodyPurpose",
             "type": "named"
           },
           "http": {
@@ -6953,7 +6953,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "TestHelpersCode",
+              "name": "PostTestHelpersTreasuryInboundTransfersIdFailBodyFailureDetailsCode",
               "type": "named"
             }
           },
@@ -9496,448 +9496,14 @@
         "type": "boolean"
       }
     },
-    "CheckoutAddress": {
+    "FindPetsByStatusStatus": {
       "aggregate_functions": {},
       "comparison_operators": {},
       "representation": {
         "one_of": [
-          "auto",
-          "never"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutAllowedCountries": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "AC",
-          "AD"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutAmountTaxDisplay": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "",
-          "exclude_tax",
-          "include_inclusive_tax"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutBillingAddressCollection": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "auto",
-          "required"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutCaptureMethod": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "automatic",
-          "automatic_async",
-          "manual"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutClient": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "android",
-          "ios",
-          "web"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutCurrency": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "cad",
-          "usd"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutCustomerCreation": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "always",
-          "if_required"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutDefaultFor": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "invoice",
-          "subscription"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutFundingType": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "bank_transfer"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutInterval": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "day",
-          "month",
-          "week",
-          "year"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutLocale": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "auto",
-          "bg",
-          "cs"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutMissingPaymentMethod": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "cancel",
-          "create_invoice",
-          "pause"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutMode": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "payment",
-          "setup",
-          "subscription"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutName": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "auto",
-          "never"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutPaymentMethodCollection": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "always",
-          "if_required"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutPaymentMethodTypes": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "acss_debit",
-          "affirm"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutPaymentSchedule": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "combined",
-          "interval",
-          "sporadic"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutPermissions": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "balances",
-          "ownership",
-          "payment_method",
-          "transactions"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutPosition": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "auto",
-          "hidden"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutPreferredLocale": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "cs-CZ",
-          "da-DK"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutPrefetch": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "balances",
-          "transactions"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutPromotions": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "auto",
-          "none"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutProrationBehavior": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "create_prorations",
-          "none"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutRedirectOnCompletion": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "always",
-          "if_required",
-          "never"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutRequestThreeDSecure": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "any",
-          "automatic",
-          "challenge"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutRequestedAddressTypes": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "aba",
-          "iban"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutSetupFutureUsage": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "off_session",
-          "on_session"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutShipping": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "auto",
-          "never"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutSubmitType": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "auto",
-          "book",
-          "donate",
-          "pay"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutTaxBehavior": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "exclusive",
-          "inclusive",
-          "unspecified"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutTermsOfService": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "none",
-          "required"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutTransactionType": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "business",
-          "personal"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutType": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "account",
-          "self"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutUiMode": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "embedded",
-          "hosted"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutUnit": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "business_day",
-          "day",
-          "hour",
-          "month",
-          "week"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutVerificationMethod": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "automatic",
-          "instant",
-          "microdeposits"
-        ],
-        "type": "enum"
-      }
-    },
-    "FilesPurpose": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "account_requirement",
-          "additional_verification",
-          "business_icon",
-          "business_logo",
-          "customer_signature",
-          "dispute_evidence",
-          "identity_document",
-          "issuing_regulatory_reporting",
-          "pci_document",
-          "tax_document_user_upload",
-          "terminal_reader_splashscreen"
+          "available",
+          "pending",
+          "sold"
         ],
         "type": "enum"
       }
@@ -9947,6 +9513,52 @@
       "comparison_operators": {},
       "representation": {
         "type": "float64"
+      }
+    },
+    "GetInvoicesCollectionMethod": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "charge_automatically",
+          "send_invoice"
+        ],
+        "type": "enum"
+      }
+    },
+    "GetInvoicesResultObject": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "list"
+        ],
+        "type": "enum"
+      }
+    },
+    "GetInvoicesStatus": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "draft",
+          "open",
+          "paid",
+          "uncollectible",
+          "void"
+        ],
+        "type": "enum"
+      }
+    },
+    "GetSearchXmlIn": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "projects",
+          "packages"
+        ],
+        "type": "enum"
       }
     },
     "Int32": {
@@ -9961,41 +9573,6 @@
       "comparison_operators": {},
       "representation": {
         "type": "int64"
-      }
-    },
-    "InvoicesCollectionMethod": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "charge_automatically",
-          "send_invoice"
-        ],
-        "type": "enum"
-      }
-    },
-    "InvoicesObject": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "list"
-        ],
-        "type": "enum"
-      }
-    },
-    "InvoicesStatus": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "draft",
-          "open",
-          "paid",
-          "uncollectible",
-          "void"
-        ],
-        "type": "enum"
       }
     },
     "JSON": {
@@ -10036,6 +9613,61 @@
         "type": "enum"
       }
     },
+    "PostCheckoutSessionsBodyAutomaticTaxLiabilityType": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "account",
+          "self"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyBillingAddressCollection": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "auto",
+          "required"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyConsentCollectionPaymentMethodReuseAgreementPosition": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "auto",
+          "hidden"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyConsentCollectionPromotions": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "auto",
+          "none"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyConsentCollectionTermsOfService": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "none",
+          "required"
+        ],
+        "type": "enum"
+      }
+    },
     "PostCheckoutSessionsBodyCustomFieldsLabelType": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -10058,6 +9690,201 @@
         "type": "enum"
       }
     },
+    "PostCheckoutSessionsBodyCustomerCreation": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "always",
+          "if_required"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyCustomerUpdateAddress": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "auto",
+          "never"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyCustomerUpdateName": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "auto",
+          "never"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyCustomerUpdateShipping": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "auto",
+          "never"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyInvoiceCreationInvoiceDataIssuerType": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "account",
+          "self"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyInvoiceCreationInvoiceDataRenderingOptionsAmountTaxDisplay": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "",
+          "exclude_tax",
+          "include_inclusive_tax"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyLineItemsPriceDataRecurringInterval": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "day",
+          "month",
+          "week",
+          "year"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyLineItemsPriceDataTaxBehavior": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "exclusive",
+          "inclusive",
+          "unspecified"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyLocale": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "auto",
+          "bg",
+          "cs"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyMode": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "payment",
+          "setup",
+          "subscription"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentIntentDataCaptureMethod": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "automatic",
+          "automatic_async",
+          "manual"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentIntentDataSetupFutureUsage": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "off_session",
+          "on_session"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodCollection": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "always",
+          "if_required"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitCurrency": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "cad",
+          "usd"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "invoice",
+          "subscription"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "combined",
+          "interval",
+          "sporadic"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitMandateOptionsTransactionType": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "business",
+          "personal"
+        ],
+        "type": "enum"
+      }
+    },
     "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitSetupFutureUsage": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -10066,6 +9893,18 @@
           "none",
           "off_session",
           "on_session"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitVerificationMethod": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "automatic",
+          "instant",
+          "microdeposits"
         ],
         "type": "enum"
       }
@@ -10144,6 +9983,29 @@
         "type": "enum"
       }
     },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsCardRequestThreeDSecure": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "any",
+          "automatic",
+          "challenge"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsCardSetupFutureUsage": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "off_session",
+          "on_session"
+        ],
+        "type": "enum"
+      }
+    },
     "PostCheckoutSessionsBodyPaymentMethodOptionsCashappSetupFutureUsage": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -10156,6 +10018,17 @@
         "type": "enum"
       }
     },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "aba",
+          "iban"
+        ],
+        "type": "enum"
+      }
+    },
     "PostCheckoutSessionsBodyPaymentMethodOptionsCustomerBalanceBankTransferType": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -10163,6 +10036,16 @@
         "one_of": [
           "eu_bank_transfer",
           "gb_bank_transfer"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsCustomerBalanceFundingType": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "bank_transfer"
         ],
         "type": "enum"
       }
@@ -10299,6 +10182,17 @@
         "type": "enum"
       }
     },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsPaypalPreferredLocale": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "cs-CZ",
+          "da-DK"
+        ],
+        "type": "enum"
+      }
+    },
     "PostCheckoutSessionsBodyPaymentMethodOptionsPaypalSetupFutureUsage": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -10344,6 +10238,30 @@
         "type": "enum"
       }
     },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "balances",
+          "ownership",
+          "payment_method",
+          "transactions"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "balances",
+          "transactions"
+        ],
+        "type": "enum"
+      }
+    },
     "PostCheckoutSessionsBodyPaymentMethodOptionsUsBankAccountSetupFutureUsage": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -10367,12 +10285,98 @@
         "type": "enum"
       }
     },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsWechatPayClient": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "android",
+          "ios",
+          "web"
+        ],
+        "type": "enum"
+      }
+    },
     "PostCheckoutSessionsBodyPaymentMethodOptionsWechatPaySetupFutureUsage": {
       "aggregate_functions": {},
       "comparison_operators": {},
       "representation": {
         "one_of": [
           "none"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodTypes": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "acss_debit",
+          "affirm"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyRedirectOnCompletion": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "always",
+          "if_required",
+          "never"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyShippingAddressCollectionAllowedCountries": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "AC",
+          "AD"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyShippingOptionsShippingRateDataDeliveryEstimateMaximumUnit": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "business_day",
+          "day",
+          "hour",
+          "month",
+          "week"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyShippingOptionsShippingRateDataDeliveryEstimateMinimumUnit": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "business_day",
+          "day",
+          "hour",
+          "month",
+          "week"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyShippingOptionsShippingRateDataTaxBehavior": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "exclusive",
+          "inclusive",
+          "unspecified"
         ],
         "type": "enum"
       }
@@ -10387,13 +10391,102 @@
         "type": "enum"
       }
     },
-    "SearchIn": {
+    "PostCheckoutSessionsBodySubmitType": {
       "aggregate_functions": {},
       "comparison_operators": {},
       "representation": {
         "one_of": [
-          "projects",
-          "packages"
+          "auto",
+          "book",
+          "donate",
+          "pay"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodySubscriptionDataInvoiceSettingsIssuerType": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "account",
+          "self"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodySubscriptionDataProrationBehavior": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "create_prorations",
+          "none"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodySubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "cancel",
+          "create_invoice",
+          "pause"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyUiMode": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "embedded",
+          "hosted"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostFilesBodyPurpose": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "account_requirement",
+          "additional_verification",
+          "business_icon",
+          "business_logo",
+          "customer_signature",
+          "dispute_evidence",
+          "identity_document",
+          "issuing_regulatory_reporting",
+          "pci_document",
+          "tax_document_user_upload",
+          "terminal_reader_splashscreen"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostTestHelpersTreasuryInboundTransfersIdFailBodyFailureDetailsCode": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "account_closed",
+          "account_frozen",
+          "bank_account_restricted",
+          "bank_ownership_changed",
+          "debit_not_authorized",
+          "incorrect_account_holder_address",
+          "incorrect_account_holder_name",
+          "incorrect_account_holder_tax_id",
+          "insufficient_funds",
+          "invalid_account_number",
+          "invalid_currency",
+          "no_account",
+          "other"
         ],
         "type": "enum"
       }
@@ -10415,28 +10508,6 @@
       "comparison_operators": {},
       "representation": {
         "type": "string"
-      }
-    },
-    "TestHelpersCode": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "account_closed",
-          "account_frozen",
-          "bank_account_restricted",
-          "bank_ownership_changed",
-          "debit_not_authorized",
-          "incorrect_account_holder_address",
-          "incorrect_account_holder_name",
-          "incorrect_account_holder_tax_id",
-          "insufficient_funds",
-          "invalid_account_number",
-          "invalid_currency",
-          "no_account",
-          "other"
-        ],
-        "type": "enum"
       }
     },
     "TimestampTZ": {

--- a/ndc-http-schema/openapi/testdata/petstore3/expected.json
+++ b/ndc-http-schema/openapi/testdata/petstore3/expected.json
@@ -105,9 +105,7 @@
             "explode": true,
             "name": "created",
             "in": "query",
-            "schema": {
-              "type": []
-            }
+            "schema": {}
           }
         },
         "customer": {
@@ -144,9 +142,7 @@
             "explode": true,
             "name": "due_date",
             "in": "query",
-            "schema": {
-              "type": []
-            }
+            "schema": {}
           }
         },
         "ending_before": {
@@ -2148,9 +2144,7 @@
               "type": "named"
             }
           },
-          "http": {
-            "type": null
-          }
+          "http": {}
         },
         "id": {
           "type": {
@@ -2279,9 +2273,7 @@
               "type": "named"
             }
           },
-          "http": {
-            "type": null
-          }
+          "http": {}
         },
         "id": {
           "type": {
@@ -6849,9 +6841,7 @@
               "type": "named"
             }
           },
-          "http": {
-            "type": []
-          }
+          "http": {}
         }
       }
     },
@@ -7752,9 +7742,7 @@
               "type": "named"
             }
           },
-          "http": {
-            "type": null
-          }
+          "http": {}
         },
         "created": {
           "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
@@ -7963,9 +7951,7 @@
               "type": "named"
             }
           },
-          "http": {
-            "type": []
-          }
+          "http": {}
         }
       }
     },

--- a/ndc-http-schema/openapi/testdata/petstore3/schema.json
+++ b/ndc-http-schema/openapi/testdata/petstore3/schema.json
@@ -350,6 +350,46 @@
     }
   ],
   "object_types": {
+    "Address": {
+      "fields": {
+        "city": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
+        "state": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
+        "street": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
+        "zip": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        }
+      }
+    },
     "AddressInput": {
       "fields": {
         "city": {
@@ -615,6 +655,74 @@
     "CreateFineTuningJobRequestInput": {
       "fields": {
         "model": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        }
+      }
+    },
+    "Customer": {
+      "fields": {
+        "address": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Address",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int64",
+              "type": "named"
+            }
+          }
+        },
+        "username": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        }
+      }
+    },
+    "CustomerInput": {
+      "fields": {
+        "address": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "AddressInput",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int64",
+              "type": "named"
+            }
+          }
+        },
+        "username": {
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -915,6 +1023,15 @@
             }
           }
         },
+        "customer": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Customer",
+              "type": "named"
+            }
+          }
+        },
         "id": {
           "type": {
             "type": "nullable",
@@ -970,6 +1087,15 @@
             "type": "nullable",
             "underlying_type": {
               "name": "Boolean",
+              "type": "named"
+            }
+          }
+        },
+        "customer": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "CustomerInput",
               "type": "named"
             }
           }

--- a/ndc-http-schema/openapi/testdata/petstore3/schema.json
+++ b/ndc-http-schema/openapi/testdata/petstore3/schema.json
@@ -8,7 +8,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "InvoicesCollectionMethod",
+              "name": "GetInvoicesCollectionMethod",
               "type": "named"
             }
           }
@@ -90,7 +90,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "InvoicesStatus",
+              "name": "GetInvoicesStatus",
               "type": "named"
             }
           }
@@ -130,7 +130,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "PetStatus",
+              "name": "FindPetsByStatusStatus",
               "type": "named"
             }
           }
@@ -253,7 +253,7 @@
         "in": {
           "description": "Where to search and apply a XPath expression: either the list of projects or the list of packages.  Example of a result when `projects` is selected: ```                                      x86_64                        x86_64                Standard OBS instance at build.opensuse.org     This instance delivers the default build targets for OBS.     https://api.opensuse.org/public     ```  Example of a result when `packages` is selected: ```                   ```",
           "type": {
-            "name": "SearchIn",
+            "name": "GetSearchXmlIn",
             "type": "named"
           }
         },
@@ -853,7 +853,7 @@
         "object": {
           "description": "String representing the object's type. Objects of the same type share the same value. Always has the value `list`.",
           "type": {
-            "name": "InvoicesObject",
+            "name": "GetInvoicesResultObject",
             "type": "named"
           }
         },
@@ -1403,7 +1403,7 @@
         },
         "type": {
           "type": {
-            "name": "CheckoutType",
+            "name": "PostCheckoutSessionsBodyAutomaticTaxLiabilityType",
             "type": "named"
           }
         }
@@ -1425,7 +1425,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutPromotions",
+              "name": "PostCheckoutSessionsBodyConsentCollectionPromotions",
               "type": "named"
             }
           }
@@ -1434,7 +1434,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutTermsOfService",
+              "name": "PostCheckoutSessionsBodyConsentCollectionTermsOfService",
               "type": "named"
             }
           }
@@ -1445,7 +1445,7 @@
       "fields": {
         "position": {
           "type": {
-            "name": "CheckoutPosition",
+            "name": "PostCheckoutSessionsBodyConsentCollectionPaymentMethodReuseAgreementPosition",
             "type": "named"
           }
         }
@@ -1686,7 +1686,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutAddress",
+              "name": "PostCheckoutSessionsBodyCustomerUpdateAddress",
               "type": "named"
             }
           }
@@ -1695,7 +1695,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutName",
+              "name": "PostCheckoutSessionsBodyCustomerUpdateName",
               "type": "named"
             }
           }
@@ -1704,7 +1704,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutShipping",
+              "name": "PostCheckoutSessionsBodyCustomerUpdateShipping",
               "type": "named"
             }
           }
@@ -1770,7 +1770,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutBillingAddressCollection",
+              "name": "PostCheckoutSessionsBodyBillingAddressCollection",
               "type": "named"
             }
           }
@@ -1853,7 +1853,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutCustomerCreation",
+              "name": "PostCheckoutSessionsBodyCustomerCreation",
               "type": "named"
             }
           }
@@ -1942,7 +1942,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutLocale",
+              "name": "PostCheckoutSessionsBodyLocale",
               "type": "named"
             }
           }
@@ -1962,7 +1962,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutMode",
+              "name": "PostCheckoutSessionsBodyMode",
               "type": "named"
             }
           }
@@ -1982,7 +1982,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutPaymentMethodCollection",
+              "name": "PostCheckoutSessionsBodyPaymentMethodCollection",
               "type": "named"
             }
           }
@@ -2013,7 +2013,7 @@
             "type": "nullable",
             "underlying_type": {
               "element_type": {
-                "name": "CheckoutPaymentMethodTypes",
+                "name": "PostCheckoutSessionsBodyPaymentMethodTypes",
                 "type": "named"
               },
               "type": "array"
@@ -2035,7 +2035,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutRedirectOnCompletion",
+              "name": "PostCheckoutSessionsBodyRedirectOnCompletion",
               "type": "named"
             }
           }
@@ -2088,7 +2088,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutSubmitType",
+              "name": "PostCheckoutSessionsBodySubmitType",
               "type": "named"
             }
           }
@@ -2128,7 +2128,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutUiMode",
+              "name": "PostCheckoutSessionsBodyUiMode",
               "type": "named"
             }
           }
@@ -2257,7 +2257,7 @@
         },
         "type": {
           "type": {
-            "name": "CheckoutType",
+            "name": "PostCheckoutSessionsBodyInvoiceCreationInvoiceDataIssuerType",
             "type": "named"
           }
         }
@@ -2269,7 +2269,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutAmountTaxDisplay",
+              "name": "PostCheckoutSessionsBodyInvoiceCreationInvoiceDataRenderingOptionsAmountTaxDisplay",
               "type": "named"
             }
           }
@@ -2407,7 +2407,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutTaxBehavior",
+              "name": "PostCheckoutSessionsBodyLineItemsPriceDataTaxBehavior",
               "type": "named"
             }
           }
@@ -2485,7 +2485,7 @@
       "fields": {
         "interval": {
           "type": {
-            "name": "CheckoutInterval",
+            "name": "PostCheckoutSessionsBodyLineItemsPriceDataRecurringInterval",
             "type": "named"
           }
         },
@@ -2516,7 +2516,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutCaptureMethod",
+              "name": "PostCheckoutSessionsBodyPaymentIntentDataCaptureMethod",
               "type": "named"
             }
           }
@@ -2561,7 +2561,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutSetupFutureUsage",
+              "name": "PostCheckoutSessionsBodyPaymentIntentDataSetupFutureUsage",
               "type": "named"
             }
           }
@@ -2745,7 +2745,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutCurrency",
+              "name": "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitCurrency",
               "type": "named"
             }
           }
@@ -2772,7 +2772,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutVerificationMethod",
+              "name": "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitVerificationMethod",
               "type": "named"
             }
           }
@@ -2795,7 +2795,7 @@
             "type": "nullable",
             "underlying_type": {
               "element_type": {
-                "name": "CheckoutDefaultFor",
+                "name": "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor",
                 "type": "named"
               },
               "type": "array"
@@ -2815,7 +2815,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutPaymentSchedule",
+              "name": "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule",
               "type": "named"
             }
           }
@@ -2824,7 +2824,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutTransactionType",
+              "name": "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitMandateOptionsTransactionType",
               "type": "named"
             }
           }
@@ -2946,7 +2946,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutRequestThreeDSecure",
+              "name": "PostCheckoutSessionsBodyPaymentMethodOptionsCardRequestThreeDSecure",
               "type": "named"
             }
           }
@@ -2955,7 +2955,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutSetupFutureUsage",
+              "name": "PostCheckoutSessionsBodyPaymentMethodOptionsCardSetupFutureUsage",
               "type": "named"
             }
           }
@@ -3032,7 +3032,7 @@
             "type": "nullable",
             "underlying_type": {
               "element_type": {
-                "name": "CheckoutRequestedAddressTypes",
+                "name": "PostCheckoutSessionsBodyPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes",
                 "type": "named"
               },
               "type": "array"
@@ -3062,7 +3062,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutFundingType",
+              "name": "PostCheckoutSessionsBodyPaymentMethodOptionsCustomerBalanceFundingType",
               "type": "named"
             }
           }
@@ -3538,7 +3538,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutPreferredLocale",
+              "name": "PostCheckoutSessionsBodyPaymentMethodOptionsPaypalPreferredLocale",
               "type": "named"
             }
           }
@@ -3644,7 +3644,7 @@
             "type": "nullable",
             "underlying_type": {
               "element_type": {
-                "name": "CheckoutPermissions",
+                "name": "PostCheckoutSessionsBodyPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions",
                 "type": "named"
               },
               "type": "array"
@@ -3656,7 +3656,7 @@
             "type": "nullable",
             "underlying_type": {
               "element_type": {
-                "name": "CheckoutPrefetch",
+                "name": "PostCheckoutSessionsBodyPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch",
                 "type": "named"
               },
               "type": "array"
@@ -3709,7 +3709,7 @@
         },
         "client": {
           "type": {
-            "name": "CheckoutClient",
+            "name": "PostCheckoutSessionsBodyPaymentMethodOptionsWechatPayClient",
             "type": "named"
           }
         },
@@ -3773,7 +3773,7 @@
         "allowed_countries": {
           "type": {
             "element_type": {
-              "name": "CheckoutAllowedCountries",
+              "name": "PostCheckoutSessionsBodyShippingAddressCollectionAllowedCountries",
               "type": "named"
             },
             "type": "array"
@@ -3829,7 +3829,7 @@
       "fields": {
         "unit": {
           "type": {
-            "name": "CheckoutUnit",
+            "name": "PostCheckoutSessionsBodyShippingOptionsShippingRateDataDeliveryEstimateMaximumUnit",
             "type": "named"
           }
         },
@@ -3845,7 +3845,7 @@
       "fields": {
         "unit": {
           "type": {
-            "name": "CheckoutUnit",
+            "name": "PostCheckoutSessionsBodyShippingOptionsShippingRateDataDeliveryEstimateMinimumUnit",
             "type": "named"
           }
         },
@@ -3921,7 +3921,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutTaxBehavior",
+              "name": "PostCheckoutSessionsBodyShippingOptionsShippingRateDataTaxBehavior",
               "type": "named"
             }
           }
@@ -4019,7 +4019,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "CheckoutProrationBehavior",
+              "name": "PostCheckoutSessionsBodySubscriptionDataProrationBehavior",
               "type": "named"
             }
           }
@@ -4088,7 +4088,7 @@
         },
         "type": {
           "type": {
-            "name": "CheckoutType",
+            "name": "PostCheckoutSessionsBodySubscriptionDataInvoiceSettingsIssuerType",
             "type": "named"
           }
         }
@@ -4117,7 +4117,7 @@
       "fields": {
         "missing_payment_method": {
           "type": {
-            "name": "CheckoutMissingPaymentMethod",
+            "name": "PostCheckoutSessionsBodySubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod",
             "type": "named"
           }
         }
@@ -4220,7 +4220,7 @@
         "purpose": {
           "description": "The [purpose](https://stripe.com/docs/file-upload#uploading-a-file) of the uploaded file.",
           "type": {
-            "name": "FilesPurpose",
+            "name": "PostFilesBodyPurpose",
             "type": "named"
           }
         }
@@ -4233,7 +4233,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "TestHelpersCode",
+              "name": "PostTestHelpersTreasuryInboundTransfersIdFailBodyFailureDetailsCode",
               "type": "named"
             }
           }
@@ -5543,448 +5543,14 @@
         "type": "boolean"
       }
     },
-    "CheckoutAddress": {
+    "FindPetsByStatusStatus": {
       "aggregate_functions": {},
       "comparison_operators": {},
       "representation": {
         "one_of": [
-          "auto",
-          "never"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutAllowedCountries": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "AC",
-          "AD"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutAmountTaxDisplay": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "",
-          "exclude_tax",
-          "include_inclusive_tax"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutBillingAddressCollection": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "auto",
-          "required"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutCaptureMethod": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "automatic",
-          "automatic_async",
-          "manual"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutClient": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "android",
-          "ios",
-          "web"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutCurrency": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "cad",
-          "usd"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutCustomerCreation": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "always",
-          "if_required"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutDefaultFor": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "invoice",
-          "subscription"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutFundingType": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "bank_transfer"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutInterval": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "day",
-          "month",
-          "week",
-          "year"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutLocale": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "auto",
-          "bg",
-          "cs"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutMissingPaymentMethod": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "cancel",
-          "create_invoice",
-          "pause"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutMode": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "payment",
-          "setup",
-          "subscription"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutName": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "auto",
-          "never"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutPaymentMethodCollection": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "always",
-          "if_required"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutPaymentMethodTypes": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "acss_debit",
-          "affirm"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutPaymentSchedule": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "combined",
-          "interval",
-          "sporadic"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutPermissions": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "balances",
-          "ownership",
-          "payment_method",
-          "transactions"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutPosition": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "auto",
-          "hidden"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutPreferredLocale": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "cs-CZ",
-          "da-DK"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutPrefetch": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "balances",
-          "transactions"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutPromotions": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "auto",
-          "none"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutProrationBehavior": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "create_prorations",
-          "none"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutRedirectOnCompletion": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "always",
-          "if_required",
-          "never"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutRequestThreeDSecure": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "any",
-          "automatic",
-          "challenge"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutRequestedAddressTypes": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "aba",
-          "iban"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutSetupFutureUsage": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "off_session",
-          "on_session"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutShipping": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "auto",
-          "never"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutSubmitType": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "auto",
-          "book",
-          "donate",
-          "pay"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutTaxBehavior": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "exclusive",
-          "inclusive",
-          "unspecified"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutTermsOfService": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "none",
-          "required"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutTransactionType": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "business",
-          "personal"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutType": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "account",
-          "self"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutUiMode": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "embedded",
-          "hosted"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutUnit": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "business_day",
-          "day",
-          "hour",
-          "month",
-          "week"
-        ],
-        "type": "enum"
-      }
-    },
-    "CheckoutVerificationMethod": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "automatic",
-          "instant",
-          "microdeposits"
-        ],
-        "type": "enum"
-      }
-    },
-    "FilesPurpose": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "account_requirement",
-          "additional_verification",
-          "business_icon",
-          "business_logo",
-          "customer_signature",
-          "dispute_evidence",
-          "identity_document",
-          "issuing_regulatory_reporting",
-          "pci_document",
-          "tax_document_user_upload",
-          "terminal_reader_splashscreen"
+          "available",
+          "pending",
+          "sold"
         ],
         "type": "enum"
       }
@@ -5994,6 +5560,52 @@
       "comparison_operators": {},
       "representation": {
         "type": "float64"
+      }
+    },
+    "GetInvoicesCollectionMethod": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "charge_automatically",
+          "send_invoice"
+        ],
+        "type": "enum"
+      }
+    },
+    "GetInvoicesResultObject": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "list"
+        ],
+        "type": "enum"
+      }
+    },
+    "GetInvoicesStatus": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "draft",
+          "open",
+          "paid",
+          "uncollectible",
+          "void"
+        ],
+        "type": "enum"
+      }
+    },
+    "GetSearchXmlIn": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "projects",
+          "packages"
+        ],
+        "type": "enum"
       }
     },
     "Int32": {
@@ -6008,41 +5620,6 @@
       "comparison_operators": {},
       "representation": {
         "type": "int64"
-      }
-    },
-    "InvoicesCollectionMethod": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "charge_automatically",
-          "send_invoice"
-        ],
-        "type": "enum"
-      }
-    },
-    "InvoicesObject": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "list"
-        ],
-        "type": "enum"
-      }
-    },
-    "InvoicesStatus": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "draft",
-          "open",
-          "paid",
-          "uncollectible",
-          "void"
-        ],
-        "type": "enum"
       }
     },
     "JSON": {
@@ -6083,6 +5660,61 @@
         "type": "enum"
       }
     },
+    "PostCheckoutSessionsBodyAutomaticTaxLiabilityType": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "account",
+          "self"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyBillingAddressCollection": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "auto",
+          "required"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyConsentCollectionPaymentMethodReuseAgreementPosition": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "auto",
+          "hidden"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyConsentCollectionPromotions": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "auto",
+          "none"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyConsentCollectionTermsOfService": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "none",
+          "required"
+        ],
+        "type": "enum"
+      }
+    },
     "PostCheckoutSessionsBodyCustomFieldsLabelType": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -6105,6 +5737,201 @@
         "type": "enum"
       }
     },
+    "PostCheckoutSessionsBodyCustomerCreation": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "always",
+          "if_required"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyCustomerUpdateAddress": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "auto",
+          "never"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyCustomerUpdateName": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "auto",
+          "never"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyCustomerUpdateShipping": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "auto",
+          "never"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyInvoiceCreationInvoiceDataIssuerType": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "account",
+          "self"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyInvoiceCreationInvoiceDataRenderingOptionsAmountTaxDisplay": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "",
+          "exclude_tax",
+          "include_inclusive_tax"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyLineItemsPriceDataRecurringInterval": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "day",
+          "month",
+          "week",
+          "year"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyLineItemsPriceDataTaxBehavior": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "exclusive",
+          "inclusive",
+          "unspecified"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyLocale": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "auto",
+          "bg",
+          "cs"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyMode": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "payment",
+          "setup",
+          "subscription"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentIntentDataCaptureMethod": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "automatic",
+          "automatic_async",
+          "manual"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentIntentDataSetupFutureUsage": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "off_session",
+          "on_session"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodCollection": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "always",
+          "if_required"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitCurrency": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "cad",
+          "usd"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "invoice",
+          "subscription"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "combined",
+          "interval",
+          "sporadic"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitMandateOptionsTransactionType": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "business",
+          "personal"
+        ],
+        "type": "enum"
+      }
+    },
     "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitSetupFutureUsage": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -6113,6 +5940,18 @@
           "none",
           "off_session",
           "on_session"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsAcssDebitVerificationMethod": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "automatic",
+          "instant",
+          "microdeposits"
         ],
         "type": "enum"
       }
@@ -6191,6 +6030,29 @@
         "type": "enum"
       }
     },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsCardRequestThreeDSecure": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "any",
+          "automatic",
+          "challenge"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsCardSetupFutureUsage": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "off_session",
+          "on_session"
+        ],
+        "type": "enum"
+      }
+    },
     "PostCheckoutSessionsBodyPaymentMethodOptionsCashappSetupFutureUsage": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -6203,6 +6065,17 @@
         "type": "enum"
       }
     },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "aba",
+          "iban"
+        ],
+        "type": "enum"
+      }
+    },
     "PostCheckoutSessionsBodyPaymentMethodOptionsCustomerBalanceBankTransferType": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -6210,6 +6083,16 @@
         "one_of": [
           "eu_bank_transfer",
           "gb_bank_transfer"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsCustomerBalanceFundingType": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "bank_transfer"
         ],
         "type": "enum"
       }
@@ -6346,6 +6229,17 @@
         "type": "enum"
       }
     },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsPaypalPreferredLocale": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "cs-CZ",
+          "da-DK"
+        ],
+        "type": "enum"
+      }
+    },
     "PostCheckoutSessionsBodyPaymentMethodOptionsPaypalSetupFutureUsage": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -6391,6 +6285,30 @@
         "type": "enum"
       }
     },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "balances",
+          "ownership",
+          "payment_method",
+          "transactions"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "balances",
+          "transactions"
+        ],
+        "type": "enum"
+      }
+    },
     "PostCheckoutSessionsBodyPaymentMethodOptionsUsBankAccountSetupFutureUsage": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -6414,12 +6332,98 @@
         "type": "enum"
       }
     },
+    "PostCheckoutSessionsBodyPaymentMethodOptionsWechatPayClient": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "android",
+          "ios",
+          "web"
+        ],
+        "type": "enum"
+      }
+    },
     "PostCheckoutSessionsBodyPaymentMethodOptionsWechatPaySetupFutureUsage": {
       "aggregate_functions": {},
       "comparison_operators": {},
       "representation": {
         "one_of": [
           "none"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyPaymentMethodTypes": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "acss_debit",
+          "affirm"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyRedirectOnCompletion": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "always",
+          "if_required",
+          "never"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyShippingAddressCollectionAllowedCountries": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "AC",
+          "AD"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyShippingOptionsShippingRateDataDeliveryEstimateMaximumUnit": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "business_day",
+          "day",
+          "hour",
+          "month",
+          "week"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyShippingOptionsShippingRateDataDeliveryEstimateMinimumUnit": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "business_day",
+          "day",
+          "hour",
+          "month",
+          "week"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyShippingOptionsShippingRateDataTaxBehavior": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "exclusive",
+          "inclusive",
+          "unspecified"
         ],
         "type": "enum"
       }
@@ -6434,13 +6438,102 @@
         "type": "enum"
       }
     },
-    "SearchIn": {
+    "PostCheckoutSessionsBodySubmitType": {
       "aggregate_functions": {},
       "comparison_operators": {},
       "representation": {
         "one_of": [
-          "projects",
-          "packages"
+          "auto",
+          "book",
+          "donate",
+          "pay"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodySubscriptionDataInvoiceSettingsIssuerType": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "account",
+          "self"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodySubscriptionDataProrationBehavior": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "create_prorations",
+          "none"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodySubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "cancel",
+          "create_invoice",
+          "pause"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostCheckoutSessionsBodyUiMode": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "embedded",
+          "hosted"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostFilesBodyPurpose": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "account_requirement",
+          "additional_verification",
+          "business_icon",
+          "business_logo",
+          "customer_signature",
+          "dispute_evidence",
+          "identity_document",
+          "issuing_regulatory_reporting",
+          "pci_document",
+          "tax_document_user_upload",
+          "terminal_reader_splashscreen"
+        ],
+        "type": "enum"
+      }
+    },
+    "PostTestHelpersTreasuryInboundTransfersIdFailBodyFailureDetailsCode": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "account_closed",
+          "account_frozen",
+          "bank_account_restricted",
+          "bank_ownership_changed",
+          "debit_not_authorized",
+          "incorrect_account_holder_address",
+          "incorrect_account_holder_name",
+          "incorrect_account_holder_tax_id",
+          "insufficient_funds",
+          "invalid_account_number",
+          "invalid_currency",
+          "no_account",
+          "other"
         ],
         "type": "enum"
       }
@@ -6462,28 +6555,6 @@
       "comparison_operators": {},
       "representation": {
         "type": "string"
-      }
-    },
-    "TestHelpersCode": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "account_closed",
-          "account_frozen",
-          "bank_account_restricted",
-          "bank_ownership_changed",
-          "debit_not_authorized",
-          "incorrect_account_holder_address",
-          "incorrect_account_holder_name",
-          "incorrect_account_holder_tax_id",
-          "insufficient_funds",
-          "invalid_account_number",
-          "invalid_currency",
-          "no_account",
-          "other"
-        ],
-        "type": "enum"
       }
     },
     "TimestampTZ": {

--- a/ndc-http-schema/openapi/testdata/petstore3/source.json
+++ b/ndc-http-schema/openapi/testdata/petstore3/source.json
@@ -3794,6 +3794,16 @@
           },
           "complete": {
             "type": "boolean"
+          },
+          "customer": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Customer"
+              }
+            ]
           }
         },
         "xml": {

--- a/ndc-http-schema/openapi/testdata/prefix3/expected_multi_words.json
+++ b/ndc-http-schema/openapi/testdata/prefix3/expected_multi_words.json
@@ -402,8 +402,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "JSON",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "JSON",
+                "type": "named"
+              }
             }
           },
           "http": {
@@ -417,8 +420,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "JSON",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "JSON",
+                "type": "named"
+              }
             }
           },
           "http": {

--- a/ndc-http-schema/openapi/testdata/prefix3/expected_multi_words.json
+++ b/ndc-http-schema/openapi/testdata/prefix3/expected_multi_words.json
@@ -137,7 +137,6 @@
             }
           },
           "http": {
-            "type": [],
             "xml": {
               "name": "Notification200Errors"
             }
@@ -698,7 +697,7 @@
           }
         },
         "converted": {
-          "description": "Number of users who have clicked / tapped on your notification.",
+          "description": "Number of messages that were clicked.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -713,7 +712,7 @@
           }
         },
         "errored": {
-          "description": "Number of notifications that could not be delivered due to an error. You can find more information by viewing the notification in the dashboard.",
+          "description": "Number of errors reported.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -750,7 +749,7 @@
           }
         },
         "failed": {
-          "description": "Number of notifications that could not be delivered due to those devices being unsubscribed.",
+          "description": "Number of messages sent to unsubscribed devices.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -912,7 +911,7 @@
           }
         },
         "received": {
-          "description": "Confirmed Deliveries number of devices that received the push notification. Paid Feature Only. Free accounts will see 0.",
+          "description": "Number of devices that received the message.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -972,7 +971,7 @@
           }
         },
         "successful": {
-          "description": "Number of notifications that were successfully delivered.",
+          "description": "Number of messages delivered to push servers, mobile carriers, or email service providers.",
           "type": {
             "type": "nullable",
             "underlying_type": {

--- a/ndc-http-schema/openapi/testdata/prefix3/expected_multi_words.json
+++ b/ndc-http-schema/openapi/testdata/prefix3/expected_multi_words.json
@@ -1235,7 +1235,15 @@
             "type": "named"
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ],
+              "xml": {
+                "name": "Notification"
+              }
+            }
           }
         }
       },

--- a/ndc-http-schema/openapi/testdata/prefix3/expected_multi_words.schema.json
+++ b/ndc-http-schema/openapi/testdata/prefix3/expected_multi_words.schema.json
@@ -416,7 +416,7 @@
           }
         },
         "converted": {
-          "description": "Number of users who have clicked / tapped on your notification.",
+          "description": "Number of messages that were clicked.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -426,7 +426,7 @@
           }
         },
         "errored": {
-          "description": "Number of notifications that could not be delivered due to an error. You can find more information by viewing the notification in the dashboard.",
+          "description": "Number of errors reported.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -448,7 +448,7 @@
           }
         },
         "failed": {
-          "description": "Number of notifications that could not be delivered due to those devices being unsubscribed.",
+          "description": "Number of messages sent to unsubscribed devices.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -544,7 +544,7 @@
           }
         },
         "received": {
-          "description": "Confirmed Deliveries number of devices that received the push notification. Paid Feature Only. Free accounts will see 0.",
+          "description": "Number of devices that received the message.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -583,7 +583,7 @@
           }
         },
         "successful": {
-          "description": "Number of notifications that were successfully delivered.",
+          "description": "Number of messages delivered to push servers, mobile carriers, or email service providers.",
           "type": {
             "type": "nullable",
             "underlying_type": {

--- a/ndc-http-schema/openapi/testdata/prefix3/expected_multi_words.schema.json
+++ b/ndc-http-schema/openapi/testdata/prefix3/expected_multi_words.schema.json
@@ -235,8 +235,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "JSON",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "JSON",
+                "type": "named"
+              }
             }
           }
         },
@@ -245,8 +248,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "JSON",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "JSON",
+                "type": "named"
+              }
             }
           }
         },

--- a/ndc-http-schema/openapi/testdata/prefix3/expected_single_word.json
+++ b/ndc-http-schema/openapi/testdata/prefix3/expected_single_word.json
@@ -402,8 +402,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "JSON",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "JSON",
+                "type": "named"
+              }
             }
           },
           "http": {
@@ -417,8 +420,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "JSON",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "JSON",
+                "type": "named"
+              }
             }
           },
           "http": {

--- a/ndc-http-schema/openapi/testdata/prefix3/expected_single_word.json
+++ b/ndc-http-schema/openapi/testdata/prefix3/expected_single_word.json
@@ -137,7 +137,6 @@
             }
           },
           "http": {
-            "type": [],
             "xml": {
               "name": "Notification200Errors"
             }
@@ -698,7 +697,7 @@
           }
         },
         "converted": {
-          "description": "Number of users who have clicked / tapped on your notification.",
+          "description": "Number of messages that were clicked.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -713,7 +712,7 @@
           }
         },
         "errored": {
-          "description": "Number of notifications that could not be delivered due to an error. You can find more information by viewing the notification in the dashboard.",
+          "description": "Number of errors reported.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -750,7 +749,7 @@
           }
         },
         "failed": {
-          "description": "Number of notifications that could not be delivered due to those devices being unsubscribed.",
+          "description": "Number of messages sent to unsubscribed devices.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -912,7 +911,7 @@
           }
         },
         "received": {
-          "description": "Confirmed Deliveries number of devices that received the push notification. Paid Feature Only. Free accounts will see 0.",
+          "description": "Number of devices that received the message.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -972,7 +971,7 @@
           }
         },
         "successful": {
-          "description": "Number of notifications that were successfully delivered.",
+          "description": "Number of messages delivered to push servers, mobile carriers, or email service providers.",
           "type": {
             "type": "nullable",
             "underlying_type": {

--- a/ndc-http-schema/openapi/testdata/prefix3/expected_single_word.json
+++ b/ndc-http-schema/openapi/testdata/prefix3/expected_single_word.json
@@ -1235,7 +1235,15 @@
             "type": "named"
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ],
+              "xml": {
+                "name": "Notification"
+              }
+            }
           }
         }
       },

--- a/ndc-http-schema/openapi/testdata/prefix3/expected_single_word.schema.json
+++ b/ndc-http-schema/openapi/testdata/prefix3/expected_single_word.schema.json
@@ -416,7 +416,7 @@
           }
         },
         "converted": {
-          "description": "Number of users who have clicked / tapped on your notification.",
+          "description": "Number of messages that were clicked.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -426,7 +426,7 @@
           }
         },
         "errored": {
-          "description": "Number of notifications that could not be delivered due to an error. You can find more information by viewing the notification in the dashboard.",
+          "description": "Number of errors reported.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -448,7 +448,7 @@
           }
         },
         "failed": {
-          "description": "Number of notifications that could not be delivered due to those devices being unsubscribed.",
+          "description": "Number of messages sent to unsubscribed devices.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -544,7 +544,7 @@
           }
         },
         "received": {
-          "description": "Confirmed Deliveries number of devices that received the push notification. Paid Feature Only. Free accounts will see 0.",
+          "description": "Number of devices that received the message.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -583,7 +583,7 @@
           }
         },
         "successful": {
-          "description": "Number of notifications that were successfully delivered.",
+          "description": "Number of messages delivered to push servers, mobile carriers, or email service providers.",
           "type": {
             "type": "nullable",
             "underlying_type": {

--- a/ndc-http-schema/openapi/testdata/prefix3/expected_single_word.schema.json
+++ b/ndc-http-schema/openapi/testdata/prefix3/expected_single_word.schema.json
@@ -235,8 +235,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "JSON",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "JSON",
+                "type": "named"
+              }
             }
           }
         },
@@ -245,8 +248,11 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "JSON",
-              "type": "named"
+              "type": "nullable",
+              "underlying_type": {
+                "name": "JSON",
+                "type": "named"
+              }
             }
           }
         },

--- a/ndc-http-schema/openapi/testdata/union2/expected.json
+++ b/ndc-http-schema/openapi/testdata/union2/expected.json
@@ -20,7 +20,26 @@
       }
     }
   },
-  "functions": {},
+  "functions": {
+    "getPet": {
+      "request": {
+        "url": "/pet",
+        "method": "get",
+        "response": {
+          "contentType": "application/json"
+        }
+      },
+      "arguments": {},
+      "description": "GET /pet",
+      "result_type": {
+        "element_type": {
+          "name": "GetPetResult",
+          "type": "named"
+        },
+        "type": "array"
+      }
+    }
+  },
   "object_types": {
     "CatInput": {
       "fields": {
@@ -61,9 +80,7 @@
             "type": [
               "array"
             ],
-            "items": {
-              "type": []
-            }
+            "items": {}
           }
         },
         "type": {
@@ -136,6 +153,98 @@
         "name": "Dog"
       }
     },
+    "GetPetResult": {
+      "fields": {
+        "age": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int32",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "integer"
+            ]
+          }
+        },
+        "icon": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "metadata": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "JSON",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          },
+          "http": {
+            "type": [
+              "array"
+            ],
+            "items": {}
+          }
+        },
+        "text": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "type": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "GetPetResultTypeEnum",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        }
+      }
+    },
     "Pet": {
       "fields": {
         "age": {
@@ -192,9 +301,7 @@
             "type": [
               "array"
             ],
-            "items": {
-              "type": []
-            }
+            "items": {}
           }
         },
         "text": {
@@ -326,6 +433,17 @@
       "comparison_operators": {},
       "representation": {
         "one_of": [
+          "dog"
+        ],
+        "type": "enum"
+      }
+    },
+    "GetPetResultTypeEnum": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "cat",
           "dog"
         ],
         "type": "enum"

--- a/ndc-http-schema/openapi/testdata/union2/expected.json
+++ b/ndc-http-schema/openapi/testdata/union2/expected.json
@@ -22,15 +22,12 @@
   },
   "functions": {},
   "object_types": {
-    "Pet": {
+    "CatInput": {
       "fields": {
         "age": {
           "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "Int32",
-              "type": "named"
-            }
+            "name": "Int32",
+            "type": "named"
           },
           "http": {
             "type": [
@@ -38,27 +35,10 @@
             ]
           }
         },
-        "icon": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          },
-          "http": {
-            "type": [
-              "string"
-            ]
-          }
-        },
         "id": {
           "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
+            "name": "String",
+            "type": "named"
           },
           "http": {
             "type": [
@@ -86,13 +66,53 @@
             }
           }
         },
-        "text": {
+        "type": {
+          "type": {
+            "name": "CatType",
+            "type": "named"
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        }
+      },
+      "xml": {
+        "name": "Cat"
+      }
+    },
+    "DogInput": {
+      "fields": {
+        "icon": {
           "type": {
             "type": "nullable",
             "underlying_type": {
               "name": "String",
               "type": "named"
             }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "id": {
+          "type": {
+            "name": "String",
+            "type": "named"
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "text": {
+          "type": {
+            "name": "String",
+            "type": "named"
           },
           "http": {
             "type": [
@@ -102,26 +122,8 @@
         },
         "type": {
           "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "PetTypeEnum",
-              "type": "named"
-            }
-          },
-          "http": {
-            "type": [
-              "string"
-            ]
-          }
-        },
-        "value": {
-          "description": "The value of this recipient's custom field",
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
+            "name": "DogType",
+            "type": "named"
           },
           "http": {
             "type": [
@@ -129,9 +131,12 @@
             ]
           }
         }
+      },
+      "xml": {
+        "name": "Dog"
       }
     },
-    "PetBodyInput": {
+    "Pet": {
       "fields": {
         "age": {
           "type": {
@@ -207,7 +212,22 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "PetBodyTypeEnum",
+              "name": "PetTypeEnum",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "value": {
+          "description": "The value of this recipient's custom field",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
               "type": "named"
             }
           },
@@ -221,7 +241,7 @@
     }
   },
   "procedures": {
-    "addPet": {
+    "addPet_Cat": {
       "request": {
         "url": "/pet",
         "method": "post",
@@ -234,9 +254,9 @@
       },
       "arguments": {
         "body": {
-          "description": "Pet object that needs to be added to the store",
+          "description": "Request body of POST /pet",
           "type": {
-            "name": "PetBodyInput",
+            "name": "CatInput",
             "type": "named"
           },
           "http": {
@@ -244,10 +264,41 @@
             "schema": {
               "type": [
                 "object"
-              ],
-              "xml": {
-                "name": "PetBody"
-              }
+              ]
+            }
+          }
+        }
+      },
+      "description": "Add a new pet to the store",
+      "result_type": {
+        "name": "Pet",
+        "type": "named"
+      }
+    },
+    "addPet_Dog": {
+      "request": {
+        "url": "/pet",
+        "method": "post",
+        "requestBody": {
+          "contentType": "application/json"
+        },
+        "response": {
+          "contentType": "application/json"
+        }
+      },
+      "arguments": {
+        "body": {
+          "description": "Request body of POST /pet",
+          "type": {
+            "name": "DogInput",
+            "type": "named"
+          },
+          "http": {
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ]
             }
           }
         }
@@ -260,6 +311,26 @@
     }
   },
   "scalar_types": {
+    "CatType": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "cat"
+        ],
+        "type": "enum"
+      }
+    },
+    "DogType": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "dog"
+        ],
+        "type": "enum"
+      }
+    },
     "Int32": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -272,17 +343,6 @@
       "comparison_operators": {},
       "representation": {
         "type": "json"
-      }
-    },
-    "PetBodyTypeEnum": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "cat",
-          "dog"
-        ],
-        "type": "enum"
       }
     },
     "PetTypeEnum": {

--- a/ndc-http-schema/openapi/testdata/union2/schema.json
+++ b/ndc-http-schema/openapi/testdata/union2/schema.json
@@ -2,33 +2,18 @@
   "collections": [],
   "functions": [],
   "object_types": {
-    "Pet": {
+    "CatInput": {
       "fields": {
         "age": {
           "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "Int32",
-              "type": "named"
-            }
-          }
-        },
-        "icon": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
+            "name": "Int32",
+            "type": "named"
           }
         },
         "id": {
           "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
+            "name": "String",
+            "type": "named"
           }
         },
         "metadata": {
@@ -43,37 +28,46 @@
             }
           }
         },
-        "text": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          }
-        },
         "type": {
           "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "PetTypeEnum",
-              "type": "named"
-            }
-          }
-        },
-        "value": {
-          "description": "The value of this recipient's custom field",
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
+            "name": "CatType",
+            "type": "named"
           }
         }
       }
     },
-    "PetBodyInput": {
+    "DogInput": {
+      "fields": {
+        "icon": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
+        "id": {
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        },
+        "text": {
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        },
+        "type": {
+          "type": {
+            "name": "DogType",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "Pet": {
       "fields": {
         "age": {
           "type": {
@@ -121,7 +115,17 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "PetBodyTypeEnum",
+              "name": "PetTypeEnum",
+              "type": "named"
+            }
+          }
+        },
+        "value": {
+          "description": "The value of this recipient's custom field",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
               "type": "named"
             }
           }
@@ -133,15 +137,32 @@
     {
       "arguments": {
         "body": {
-          "description": "Pet object that needs to be added to the store",
+          "description": "Request body of POST /pet",
           "type": {
-            "name": "PetBodyInput",
+            "name": "CatInput",
             "type": "named"
           }
         }
       },
       "description": "Add a new pet to the store",
-      "name": "addPet",
+      "name": "addPet_Cat",
+      "result_type": {
+        "name": "Pet",
+        "type": "named"
+      }
+    },
+    {
+      "arguments": {
+        "body": {
+          "description": "Request body of POST /pet",
+          "type": {
+            "name": "DogInput",
+            "type": "named"
+          }
+        }
+      },
+      "description": "Add a new pet to the store",
+      "name": "addPet_Dog",
       "result_type": {
         "name": "Pet",
         "type": "named"
@@ -149,6 +170,26 @@
     }
   ],
   "scalar_types": {
+    "CatType": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "cat"
+        ],
+        "type": "enum"
+      }
+    },
+    "DogType": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "dog"
+        ],
+        "type": "enum"
+      }
+    },
     "Int32": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -161,17 +202,6 @@
       "comparison_operators": {},
       "representation": {
         "type": "json"
-      }
-    },
-    "PetBodyTypeEnum": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "cat",
-          "dog"
-        ],
-        "type": "enum"
       }
     },
     "PetTypeEnum": {

--- a/ndc-http-schema/openapi/testdata/union2/schema.json
+++ b/ndc-http-schema/openapi/testdata/union2/schema.json
@@ -1,6 +1,19 @@
 {
   "collections": [],
-  "functions": [],
+  "functions": [
+    {
+      "arguments": {},
+      "description": "GET /pet",
+      "name": "getPet",
+      "result_type": {
+        "element_type": {
+          "name": "GetPetResult",
+          "type": "named"
+        },
+        "type": "array"
+      }
+    }
+  ],
   "object_types": {
     "CatInput": {
       "fields": {
@@ -63,6 +76,67 @@
           "type": {
             "name": "DogType",
             "type": "named"
+          }
+        }
+      }
+    },
+    "GetPetResult": {
+      "fields": {
+        "age": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int32",
+              "type": "named"
+            }
+          }
+        },
+        "icon": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
+        "id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
+        "metadata": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "JSON",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "text": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
+        "type": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "GetPetResultTypeEnum",
+              "type": "named"
+            }
           }
         }
       }
@@ -185,6 +259,17 @@
       "comparison_operators": {},
       "representation": {
         "one_of": [
+          "dog"
+        ],
+        "type": "enum"
+      }
+    },
+    "GetPetResultTypeEnum": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "cat",
           "dog"
         ],
         "type": "enum"

--- a/ndc-http-schema/openapi/testdata/union2/source.json
+++ b/ndc-http-schema/openapi/testdata/union2/source.json
@@ -35,7 +35,7 @@
   },
   "definitions": {
     "PetBody": {
-      "allOf": [
+      "oneOf": [
         {
           "$ref": "#/definitions/Dog"
         },
@@ -45,7 +45,7 @@
       ]
     },
     "Pet": {
-      "oneOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/Dog"
         },

--- a/ndc-http-schema/openapi/testdata/union2/source.json
+++ b/ndc-http-schema/openapi/testdata/union2/source.json
@@ -5,6 +5,31 @@
   "schemes": ["https", "http"],
   "paths": {
     "/pet": {
+      "get": {
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Cat"
+                  }
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Dog"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
       "post": {
         "tags": ["pet"],
         "summary": "Add a new pet to the store",

--- a/ndc-http-schema/openapi/testdata/union3/expected.json
+++ b/ndc-http-schema/openapi/testdata/union3/expected.json
@@ -786,17 +786,12 @@
             "type": "named"
           },
           "http": {
-            "in": "body"
-          }
-        },
-        "paramBody": {
-          "description": "Request body of POST /pets",
-          "type": {
-            "name": "DogInput",
-            "type": "named"
-          },
-          "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ]
+            }
           }
         }
       },
@@ -821,21 +816,16 @@
         "body": {
           "description": "Request body of POST /pets",
           "type": {
-            "name": "CatInput",
-            "type": "named"
-          },
-          "http": {
-            "in": "body"
-          }
-        },
-        "paramBody": {
-          "description": "Request body of POST /pets",
-          "type": {
             "name": "DogInput",
             "type": "named"
           },
           "http": {
-            "in": "body"
+            "in": "body",
+            "schema": {
+              "type": [
+                "object"
+              ]
+            }
           }
         }
       },

--- a/ndc-http-schema/openapi/testdata/union3/expected.json
+++ b/ndc-http-schema/openapi/testdata/union3/expected.json
@@ -767,7 +767,7 @@
     }
   },
   "procedures": {
-    "postPetsCat": {
+    "postPets_Cat": {
       "request": {
         "url": "/pets",
         "method": "post",
@@ -801,7 +801,7 @@
         "type": "named"
       }
     },
-    "postPetsDog": {
+    "postPets_Dog": {
       "request": {
         "url": "/pets",
         "method": "post",

--- a/ndc-http-schema/openapi/testdata/union3/expected.json
+++ b/ndc-http-schema/openapi/testdata/union3/expected.json
@@ -103,6 +103,114 @@
     }
   },
   "object_types": {
+    "CatInput": {
+      "fields": {
+        "age": {
+          "type": {
+            "name": "Int32",
+            "type": "named"
+          },
+          "http": {
+            "type": [
+              "integer"
+            ]
+          }
+        },
+        "id": {
+          "type": {
+            "name": "String",
+            "type": "named"
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "metadata": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "JSON",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          },
+          "http": {
+            "type": [
+              "array"
+            ],
+            "items": {
+              "type": []
+            }
+          }
+        },
+        "type": {
+          "type": {
+            "name": "CatType",
+            "type": "named"
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        }
+      }
+    },
+    "DogInput": {
+      "fields": {
+        "icon": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "id": {
+          "type": {
+            "name": "String",
+            "type": "named"
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "text": {
+          "type": {
+            "name": "String",
+            "type": "named"
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "type": {
+          "type": {
+            "name": "DogType",
+            "type": "named"
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        }
+      }
+    },
     "PaymentSource": {
       "fields": {
         "allow_redisplay": {
@@ -558,115 +666,6 @@
       "fields": {
         "age": {
           "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "Int32",
-              "type": "named"
-            }
-          },
-          "http": {
-            "type": [
-              "integer"
-            ]
-          }
-        },
-        "icon": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          },
-          "http": {
-            "type": [
-              "string"
-            ]
-          }
-        },
-        "id": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          },
-          "http": {
-            "type": [
-              "string"
-            ]
-          }
-        },
-        "metadata": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "JSON",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          },
-          "http": {
-            "type": [
-              "array"
-            ],
-            "items": {
-              "type": []
-            }
-          }
-        },
-        "text": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          },
-          "http": {
-            "type": [
-              "string"
-            ]
-          }
-        },
-        "type": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "PetTypeEnum",
-              "type": "named"
-            }
-          },
-          "http": {
-            "type": [
-              "string"
-            ]
-          }
-        },
-        "value": {
-          "description": "The value of this recipient's custom field",
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          },
-          "http": {
-            "type": [
-              "string"
-            ]
-          }
-        }
-      }
-    },
-    "PetBodyInput": {
-      "fields": {
-        "age": {
-          "type": {
             "name": "Int32",
             "type": "named"
           },
@@ -739,7 +738,22 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "PetBodyTypeEnum",
+              "name": "PetTypeEnum",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "value": {
+          "description": "The value of this recipient's custom field",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
               "type": "named"
             }
           },
@@ -753,7 +767,7 @@
     }
   },
   "procedures": {
-    "postPets": {
+    "postPetsCat": {
       "request": {
         "url": "/pets",
         "method": "post",
@@ -768,7 +782,56 @@
         "body": {
           "description": "Request body of POST /pets",
           "type": {
-            "name": "PetBodyInput",
+            "name": "CatInput",
+            "type": "named"
+          },
+          "http": {
+            "in": "body"
+          }
+        },
+        "paramBody": {
+          "description": "Request body of POST /pets",
+          "type": {
+            "name": "DogInput",
+            "type": "named"
+          },
+          "http": {
+            "in": "body"
+          }
+        }
+      },
+      "description": "POST /pets",
+      "result_type": {
+        "name": "Pet",
+        "type": "named"
+      }
+    },
+    "postPetsDog": {
+      "request": {
+        "url": "/pets",
+        "method": "post",
+        "requestBody": {
+          "contentType": "application/json"
+        },
+        "response": {
+          "contentType": "application/json"
+        }
+      },
+      "arguments": {
+        "body": {
+          "description": "Request body of POST /pets",
+          "type": {
+            "name": "CatInput",
+            "type": "named"
+          },
+          "http": {
+            "in": "body"
+          }
+        },
+        "paramBody": {
+          "description": "Request body of POST /pets",
+          "type": {
+            "name": "DogInput",
             "type": "named"
           },
           "http": {
@@ -821,6 +884,26 @@
         "one_of": [
           "regulated",
           "unregulated"
+        ],
+        "type": "enum"
+      }
+    },
+    "CatType": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "cat"
+        ],
+        "type": "enum"
+      }
+    },
+    "DogType": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "dog"
         ],
         "type": "enum"
       }
@@ -878,17 +961,6 @@
           "standard",
           "three_d_secure",
           "wechat"
-        ],
-        "type": "enum"
-      }
-    },
-    "PetBodyTypeEnum": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "cat",
-          "dog"
         ],
         "type": "enum"
       }

--- a/ndc-http-schema/openapi/testdata/union3/expected.json
+++ b/ndc-http-schema/openapi/testdata/union3/expected.json
@@ -163,6 +163,20 @@
             "items": {}
           }
         },
+        "starred_at": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
         "type": {
           "type": {
             "name": "CatType",
@@ -201,6 +215,21 @@
             "type": [
               "string"
             ]
+          }
+        },
+        "starred_at": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ],
+            "format": "data-time"
           }
         },
         "text": {
@@ -287,6 +316,20 @@
               "array"
             ],
             "items": {}
+          }
+        },
+        "starred_at": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
           }
         },
         "text": {
@@ -827,6 +870,21 @@
               "array"
             ],
             "items": {}
+          }
+        },
+        "starred_at": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ],
+            "format": "data-time"
           }
         },
         "text": {

--- a/ndc-http-schema/openapi/testdata/union3/expected.json
+++ b/ndc-http-schema/openapi/testdata/union3/expected.json
@@ -100,6 +100,24 @@
         "name": "PaymentSource",
         "type": "named"
       }
+    },
+    "getPets": {
+      "request": {
+        "url": "/pets",
+        "method": "get",
+        "response": {
+          "contentType": "application/json"
+        }
+      },
+      "arguments": {},
+      "description": "GET /pets",
+      "result_type": {
+        "element_type": {
+          "name": "GetPetsResult",
+          "type": "named"
+        },
+        "type": "array"
+      }
     }
   },
   "object_types": {
@@ -142,9 +160,7 @@
             "type": [
               "array"
             ],
-            "items": {
-              "type": []
-            }
+            "items": {}
           }
         },
         "type": {
@@ -211,6 +227,98 @@
         }
       }
     },
+    "GetPetsResult": {
+      "fields": {
+        "age": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int32",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "integer"
+            ]
+          }
+        },
+        "icon": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "metadata": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "JSON",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          },
+          "http": {
+            "type": [
+              "array"
+            ],
+            "items": {}
+          }
+        },
+        "text": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "type": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "GetPetsResultTypeEnum",
+              "type": "named"
+            }
+          },
+          "http": {
+            "type": [
+              "string"
+            ]
+          }
+        }
+      }
+    },
     "PaymentSource": {
       "fields": {
         "allow_redisplay": {
@@ -268,7 +376,7 @@
           }
         },
         "country": {
-          "description": "Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected.",
+          "description": "The account's country.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -284,7 +392,7 @@
           }
         },
         "created": {
-          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
+          "description": "Time at which the account was connected. Measured in seconds since the Unix epoch.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -300,7 +408,7 @@
           }
         },
         "currency": {
-          "description": "Three-letter [ISO code for the currency](https://stripe.com/docs/currencies) associated with the source. This is the currency for which the source will be chargeable once ready. Required for `single_use` sources.",
+          "description": "Three-letter [ISO code for currency](https://www.iso.org/iso-4217-currency-codes.html) in lowercase. Must be a [supported currency](https://docs.stripe.com/currencies). Only applicable on accounts (not customers or recipients). The card can be used as a transfer destination for funds in this currency. This property is only available for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -348,7 +456,7 @@
           }
         },
         "default_for_currency": {
-          "description": "Whether this card is the default external account for its currency. This property is only available for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.",
+          "description": "Whether this bank account is the default external account for its currency.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -440,7 +548,7 @@
           }
         },
         "fingerprint": {
-          "description": "Uniquely identifies this particular card number. You can use this attribute to check whether two customers whove signed up with you are using the same card number, for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.  *As of May 1, 2021, card fingerprint in India for Connect changed to allow two fingerprints for the same card---one for India and one for the rest of the world.*",
+          "description": "Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -504,7 +612,7 @@
           }
         },
         "last4": {
-          "description": "The last four digits of the card.",
+          "description": "The last four digits of the bank account number.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -598,7 +706,7 @@
           }
         },
         "status": {
-          "description": "The status of the source, one of `canceled`, `chargeable`, `consumed`, `failed`, or `pending`. Only `chargeable` sources can be used to create a charge.",
+          "description": "For bank accounts, possible values are `new`, `validated`, `verified`, `verification_failed`, or `errored`. A bank account that hasn't had any activity or validation performed is `new`. If Stripe can determine that the bank account exists, its status will be `validated`. Note that there often isnt enough information to know (e.g., for smaller credit unions), and the validation is not always run. If customer bank account verification has succeeded, the bank account status will be `verified`. If the verification failed for any reason, such as microdeposit failure, the status will be `verification_failed`. If a payout sent to this bank account fails, we'll set the status to `errored` and will not continue to send [scheduled payouts](https://stripe.com/docs/payouts#payout-schedule) until the bank details are updated.  For external accounts, possible values are `new`, `errored` and `verification_failed`. If a payout fails, the status is set to `errored` and scheduled payouts are stopped until account details are updated. In the US and India, if we can't [verify the owner of the bank account](https://support.stripe.com/questions/bank-account-ownership-verification), we'll set the status to `verification_failed`. Other validations aren't run against external accounts because they're only used for payouts. This means the other statuses don't apply.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -630,7 +738,7 @@
           }
         },
         "type": {
-          "description": "The `type` of the source. The `type` is a payment method, one of `ach_credit_transfer`, `ach_debit`, `alipay`, `bancontact`, `card`, `card_present`, `eps`, `giropay`, `ideal`, `multibanco`, `klarna`, `p24`, `sepa_debit`, `sofort`, `three_d_secure`, or `wechat`. An additional hash is included on the source with a name matching this value. It contains additional information specific to the [payment method](https://stripe.com/docs/sources) used.",
+          "description": "The Stripe account type. Can be `standard`, `express`, `custom`, or `none`.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -718,9 +826,7 @@
             "type": [
               "array"
             ],
-            "items": {
-              "type": []
-            }
+            "items": {}
           }
         },
         "text": {
@@ -893,6 +999,17 @@
       "comparison_operators": {},
       "representation": {
         "one_of": [
+          "dog"
+        ],
+        "type": "enum"
+      }
+    },
+    "GetPetsResultTypeEnum": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "cat",
           "dog"
         ],
         "type": "enum"

--- a/ndc-http-schema/openapi/testdata/union3/schema.json
+++ b/ndc-http-schema/openapi/testdata/union3/schema.json
@@ -76,6 +76,15 @@
             }
           }
         },
+        "starred_at": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
         "type": {
           "type": {
             "name": "CatType",
@@ -99,6 +108,15 @@
           "type": {
             "name": "String",
             "type": "named"
+          }
+        },
+        "starred_at": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
           }
         },
         "text": {
@@ -153,6 +171,15 @@
                 "type": "named"
               },
               "type": "array"
+            }
+          }
+        },
+        "starred_at": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
             }
           }
         },
@@ -498,6 +525,15 @@
                 "type": "named"
               },
               "type": "array"
+            }
+          }
+        },
+        "starred_at": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
             }
           }
         },

--- a/ndc-http-schema/openapi/testdata/union3/schema.json
+++ b/ndc-http-schema/openapi/testdata/union3/schema.json
@@ -35,6 +35,18 @@
         "name": "PaymentSource",
         "type": "named"
       }
+    },
+    {
+      "arguments": {},
+      "description": "GET /pets",
+      "name": "getPets",
+      "result_type": {
+        "element_type": {
+          "name": "GetPetsResult",
+          "type": "named"
+        },
+        "type": "array"
+      }
     }
   ],
   "object_types": {
@@ -103,6 +115,67 @@
         }
       }
     },
+    "GetPetsResult": {
+      "fields": {
+        "age": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int32",
+              "type": "named"
+            }
+          }
+        },
+        "icon": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
+        "id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
+        "metadata": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "JSON",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "text": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
+        "type": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "GetPetsResultTypeEnum",
+              "type": "named"
+            }
+          }
+        }
+      }
+    },
     "PaymentSource": {
       "fields": {
         "allow_redisplay": {
@@ -139,7 +212,7 @@
           }
         },
         "country": {
-          "description": "Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected.",
+          "description": "The account's country.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -149,7 +222,7 @@
           }
         },
         "created": {
-          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
+          "description": "Time at which the account was connected. Measured in seconds since the Unix epoch.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -159,7 +232,7 @@
           }
         },
         "currency": {
-          "description": "Three-letter [ISO code for the currency](https://stripe.com/docs/currencies) associated with the source. This is the currency for which the source will be chargeable once ready. Required for `single_use` sources.",
+          "description": "Three-letter [ISO code for currency](https://www.iso.org/iso-4217-currency-codes.html) in lowercase. Must be a [supported currency](https://docs.stripe.com/currencies). Only applicable on accounts (not customers or recipients). The card can be used as a transfer destination for funds in this currency. This property is only available for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -189,7 +262,7 @@
           }
         },
         "default_for_currency": {
-          "description": "Whether this card is the default external account for its currency. This property is only available for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.",
+          "description": "Whether this bank account is the default external account for its currency.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -249,7 +322,7 @@
           }
         },
         "fingerprint": {
-          "description": "Uniquely identifies this particular card number. You can use this attribute to check whether two customers whove signed up with you are using the same card number, for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.  *As of May 1, 2021, card fingerprint in India for Connect changed to allow two fingerprints for the same card---one for India and one for the rest of the world.*",
+          "description": "Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -289,7 +362,7 @@
           }
         },
         "last4": {
-          "description": "The last four digits of the card.",
+          "description": "The last four digits of the bank account number.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -349,7 +422,7 @@
           }
         },
         "status": {
-          "description": "The status of the source, one of `canceled`, `chargeable`, `consumed`, `failed`, or `pending`. Only `chargeable` sources can be used to create a charge.",
+          "description": "For bank accounts, possible values are `new`, `validated`, `verified`, `verification_failed`, or `errored`. A bank account that hasn't had any activity or validation performed is `new`. If Stripe can determine that the bank account exists, its status will be `validated`. Note that there often isnt enough information to know (e.g., for smaller credit unions), and the validation is not always run. If customer bank account verification has succeeded, the bank account status will be `verified`. If the verification failed for any reason, such as microdeposit failure, the status will be `verification_failed`. If a payout sent to this bank account fails, we'll set the status to `errored` and will not continue to send [scheduled payouts](https://stripe.com/docs/payouts#payout-schedule) until the bank details are updated.  For external accounts, possible values are `new`, `errored` and `verification_failed`. If a payout fails, the status is set to `errored` and scheduled payouts are stopped until account details are updated. In the US and India, if we can't [verify the owner of the bank account](https://support.stripe.com/questions/bank-account-ownership-verification), we'll set the status to `verification_failed`. Other validations aren't run against external accounts because they're only used for payouts. This means the other statuses don't apply.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -369,7 +442,7 @@
           }
         },
         "type": {
-          "description": "The `type` of the source. The `type` is a payment method, one of `ach_credit_transfer`, `ach_debit`, `alipay`, `bancontact`, `card`, `card_present`, `eps`, `giropay`, `ideal`, `multibanco`, `klarna`, `p24`, `sepa_debit`, `sofort`, `three_d_secure`, or `wechat`. An additional hash is included on the source with a name matching this value. It contains additional information specific to the [payment method](https://stripe.com/docs/sources) used.",
+          "description": "The Stripe account type. Can be `standard`, `express`, `custom`, or `none`.",
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -549,6 +622,17 @@
       "comparison_operators": {},
       "representation": {
         "one_of": [
+          "dog"
+        ],
+        "type": "enum"
+      }
+    },
+    "GetPetsResultTypeEnum": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "cat",
           "dog"
         ],
         "type": "enum"

--- a/ndc-http-schema/openapi/testdata/union3/schema.json
+++ b/ndc-http-schema/openapi/testdata/union3/schema.json
@@ -465,13 +465,6 @@
             "name": "CatInput",
             "type": "named"
           }
-        },
-        "paramBody": {
-          "description": "Request body of POST /pets",
-          "type": {
-            "name": "DogInput",
-            "type": "named"
-          }
         }
       },
       "description": "POST /pets",
@@ -484,13 +477,6 @@
     {
       "arguments": {
         "body": {
-          "description": "Request body of POST /pets",
-          "type": {
-            "name": "CatInput",
-            "type": "named"
-          }
-        },
-        "paramBody": {
           "description": "Request body of POST /pets",
           "type": {
             "name": "DogInput",

--- a/ndc-http-schema/openapi/testdata/union3/schema.json
+++ b/ndc-http-schema/openapi/testdata/union3/schema.json
@@ -468,7 +468,7 @@
         }
       },
       "description": "POST /pets",
-      "name": "postPetsCat",
+      "name": "postPets_Cat",
       "result_type": {
         "name": "Pet",
         "type": "named"
@@ -485,7 +485,7 @@
         }
       },
       "description": "POST /pets",
-      "name": "postPetsDog",
+      "name": "postPets_Dog",
       "result_type": {
         "name": "Pet",
         "type": "named"

--- a/ndc-http-schema/openapi/testdata/union3/schema.json
+++ b/ndc-http-schema/openapi/testdata/union3/schema.json
@@ -38,6 +38,71 @@
     }
   ],
   "object_types": {
+    "CatInput": {
+      "fields": {
+        "age": {
+          "type": {
+            "name": "Int32",
+            "type": "named"
+          }
+        },
+        "id": {
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        },
+        "metadata": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "JSON",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "type": {
+          "type": {
+            "name": "CatType",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "DogInput": {
+      "fields": {
+        "icon": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
+        "id": {
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        },
+        "text": {
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        },
+        "type": {
+          "type": {
+            "name": "DogType",
+            "type": "named"
+          }
+        }
+      }
+    },
     "PaymentSource": {
       "fields": {
         "allow_redisplay": {
@@ -329,77 +394,6 @@
       "fields": {
         "age": {
           "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "Int32",
-              "type": "named"
-            }
-          }
-        },
-        "icon": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          }
-        },
-        "id": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          }
-        },
-        "metadata": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "JSON",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "text": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          }
-        },
-        "type": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "PetTypeEnum",
-              "type": "named"
-            }
-          }
-        },
-        "value": {
-          "description": "The value of this recipient's custom field",
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          }
-        }
-      }
-    },
-    "PetBodyInput": {
-      "fields": {
-        "age": {
-          "type": {
             "name": "Int32",
             "type": "named"
           }
@@ -444,7 +438,17 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "PetBodyTypeEnum",
+              "name": "PetTypeEnum",
+              "type": "named"
+            }
+          }
+        },
+        "value": {
+          "description": "The value of this recipient's custom field",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
               "type": "named"
             }
           }
@@ -458,13 +462,44 @@
         "body": {
           "description": "Request body of POST /pets",
           "type": {
-            "name": "PetBodyInput",
+            "name": "CatInput",
+            "type": "named"
+          }
+        },
+        "paramBody": {
+          "description": "Request body of POST /pets",
+          "type": {
+            "name": "DogInput",
             "type": "named"
           }
         }
       },
       "description": "POST /pets",
-      "name": "postPets",
+      "name": "postPetsCat",
+      "result_type": {
+        "name": "Pet",
+        "type": "named"
+      }
+    },
+    {
+      "arguments": {
+        "body": {
+          "description": "Request body of POST /pets",
+          "type": {
+            "name": "CatInput",
+            "type": "named"
+          }
+        },
+        "paramBody": {
+          "description": "Request body of POST /pets",
+          "type": {
+            "name": "DogInput",
+            "type": "named"
+          }
+        }
+      },
+      "description": "POST /pets",
+      "name": "postPetsDog",
       "result_type": {
         "name": "Pet",
         "type": "named"
@@ -509,6 +544,26 @@
         "one_of": [
           "regulated",
           "unregulated"
+        ],
+        "type": "enum"
+      }
+    },
+    "CatType": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "cat"
+        ],
+        "type": "enum"
+      }
+    },
+    "DogType": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "dog"
         ],
         "type": "enum"
       }
@@ -566,17 +621,6 @@
           "standard",
           "three_d_secure",
           "wechat"
-        ],
-        "type": "enum"
-      }
-    },
-    "PetBodyTypeEnum": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "cat",
-          "dog"
         ],
         "type": "enum"
       }

--- a/ndc-http-schema/openapi/testdata/union3/source.json
+++ b/ndc-http-schema/openapi/testdata/union3/source.json
@@ -57,6 +57,10 @@
           },
           "icon": {
             "type": "string"
+          },
+          "starred_at": {
+            "type": "string",
+            "format": "data-time"
           }
         },
         "required": ["id", "type", "text"]
@@ -73,6 +77,10 @@
           },
           "age": {
             "type": "integer"
+          },
+          "starred_at": {
+            "type": "string",
+            "examples": ["\"2020-07-09T00:17:42Z\""]
           },
           "metadata": {
             "type": "array",

--- a/ndc-http-schema/openapi/testdata/union3/source.json
+++ b/ndc-http-schema/openapi/testdata/union3/source.json
@@ -403,6 +403,32 @@
   },
   "paths": {
     "/pets": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Cat"
+                      }
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Dog"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
       "post": {
         "requestBody": {
           "required": true,

--- a/ndc-http-schema/openapi/testdata/union3/source.json
+++ b/ndc-http-schema/openapi/testdata/union3/source.json
@@ -14,7 +14,7 @@
     },
     "schemas": {
       "PetBody": {
-        "allOf": [
+        "oneOf": [
           {
             "$ref": "#/components/schemas/Dog"
           },
@@ -24,7 +24,7 @@
         ]
       },
       "Pet": {
-        "oneOf": [
+        "allOf": [
           {
             "$ref": "#/components/schemas/Dog"
           },

--- a/ndc-http-schema/schema/schema.go
+++ b/ndc-http-schema/schema/schema.go
@@ -149,7 +149,7 @@ type RequestParameter struct {
 // TypeSchema represents a serializable object of OpenAPI schema
 // that is used for validation
 type TypeSchema struct {
-	Type        []string    `json:"type"                mapstructure:"type"      yaml:"type"`
+	Type        []string    `json:"type,omitempty"      mapstructure:"type"      yaml:"type,omitempty"`
 	Format      string      `json:"format,omitempty"    mapstructure:"format"    yaml:"format,omitempty"`
 	Pattern     string      `json:"pattern,omitempty"   mapstructure:"pattern"   yaml:"pattern,omitempty"`
 	Maximum     *float64    `json:"maximum,omitempty"   mapstructure:"maximum"   yaml:"maximum,omitempty"`

--- a/ndc-http-schema/utils/schema.go
+++ b/ndc-http-schema/utils/schema.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/hasura/ndc-sdk-go/schema"
+)
+
+// UnwrapNullableType unwraps the underlying type of the nullable type
+func UnwrapNullableType(input schema.Type) (schema.TypeEncoder, bool, error) {
+	return UnwrapNullableTypeEncoder(input.Interface())
+}
+
+// UnwrapNullableTypeEncoder unwraps the underlying type of the nullable type
+func UnwrapNullableTypeEncoder(input schema.TypeEncoder) (schema.TypeEncoder, bool, error) {
+	switch ty := input.(type) {
+	case *schema.NullableType:
+		childType, _, err := UnwrapNullableType(ty.UnderlyingType)
+		if err != nil {
+			return nil, false, err
+		}
+
+		return childType, true, nil
+	case *schema.NamedType, *schema.ArrayType:
+		return ty, false, nil
+	default:
+		return nil, false, fmt.Errorf("invalid type %v", input)
+	}
+}


### PR DESCRIPTION
- OAS: Improve the evaluation of unknown content types.
- OAS: If the request body type is a oneOf list the API will be duplicated to multiple operations. 