### PR TITLE
feat: prepend base server URL to the relative OAuth token path 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,8 @@ jobs:
           sleep 5
           go test -v -coverpkg=./... -race -timeout 3m -coverprofile=coverage.out.tmp ./...
           docker compose down -v
-          cat coverage.out.tmp | grep -v "main.go" > coverage.out
+          cat coverage.out.tmp | grep -v "main.go" > coverage.out.tmp2
+          cat coverage.out.tmp2 | grep -v "version.go" > coverage.out
       - name: Run integration tests
         run: |
           ./scripts/test.sh

--- a/connector/internal/client.go
+++ b/connector/internal/client.go
@@ -282,7 +282,7 @@ func (client *HTTPClient) doRequest(ctx context.Context, request *RetryableReque
 	ctx, span := tracer.Start(ctx, fmt.Sprintf("%s %s", method, request.RawRequest.URL), trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
-	urlAttr := cloneURL(&request.URL)
+	urlAttr := restUtils.CloneURL(&request.URL)
 	password, hasPassword := urlAttr.User.Password()
 	if urlAttr.User.String() != "" || hasPassword {
 		maskedUser := restUtils.MaskString(urlAttr.User.Username())

--- a/connector/internal/security/auth.go
+++ b/connector/internal/security/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/url"
 
 	"github.com/hasura/ndc-http/ndc-http-schema/schema"
 )
@@ -19,7 +20,7 @@ type Credential interface {
 }
 
 // NewCredential creates a generic credential from the security scheme.
-func NewCredential(ctx context.Context, httpClient *http.Client, security schema.SecurityScheme) (Credential, bool, error) {
+func NewCredential(ctx context.Context, httpClient *http.Client, baseServerURL *url.URL, security schema.SecurityScheme) (Credential, bool, error) {
 	if security.SecuritySchemer == nil {
 		return nil, false, errors.New("empty security scheme")
 	}
@@ -44,7 +45,7 @@ func NewCredential(ctx context.Context, httpClient *http.Client, security schema
 				headerForwardingRequired = true
 			}
 
-			cred, err := NewOAuth2Client(ctx, httpClient, flowType, &flow)
+			cred, err := NewOAuth2Client(ctx, httpClient, baseServerURL, flowType, &flow)
 
 			return cred, headerForwardingRequired || err != nil, err
 		}

--- a/connector/internal/utils.go
+++ b/connector/internal/utils.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/hasura/ndc-http/ndc-http-schema/utils"
@@ -51,20 +50,4 @@ func evalForwardedHeaders(req *RetryableRequest, headers map[string]string) erro
 	}
 
 	return nil
-}
-
-func cloneURL(input *url.URL) *url.URL {
-	return &url.URL{
-		Scheme:      input.Scheme,
-		Opaque:      input.Opaque,
-		User:        input.User,
-		Host:        input.Host,
-		Path:        input.Path,
-		RawPath:     input.RawPath,
-		OmitHost:    input.OmitHost,
-		ForceQuery:  input.ForceQuery,
-		RawQuery:    input.RawQuery,
-		Fragment:    input.Fragment,
-		RawFragment: input.RawFragment,
-	}
 }

--- a/connector/testdata/auth/schema.yaml
+++ b/connector/testdata/auth/schema.yaml
@@ -3,6 +3,22 @@ settings:
   servers:
     - url:
         env: PET_STORE_URL
+    - url:
+        env: PET_STORE_URL
+      securitySchemes:
+        petstore_auth:
+          type: oauth2
+          flows:
+            clientCredentials:
+              tokenUrl:
+                value: /oauth2/token
+              clientId:
+                env: OAUTH2_CLIENT_ID
+              clientSecret:
+                env: OAUTH2_CLIENT_SECRET
+              scopes:
+                read:pets: read your pets
+                write:pets: modify pets in your account
   securitySchemes:
     api_key:
       type: apiKey

--- a/ndc-http-schema/utils/http.go
+++ b/ndc-http-schema/utils/http.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"net/url"
 	"strings"
 
 	"github.com/hasura/ndc-http/ndc-http-schema/schema"
@@ -29,4 +30,21 @@ func IsContentTypeBinary(contentType string) bool {
 // IsContentTypeMultipartForm checks the content type relates to multipart form.
 func IsContentTypeMultipartForm(contentType string) bool {
 	return strings.HasPrefix(contentType, "multipart/")
+}
+
+// CloneURL clones the input URL to a new instance.
+func CloneURL(input *url.URL) *url.URL {
+	return &url.URL{
+		Scheme:      input.Scheme,
+		Opaque:      input.Opaque,
+		User:        input.User,
+		Host:        input.Host,
+		Path:        input.Path,
+		RawPath:     input.RawPath,
+		OmitHost:    input.OmitHost,
+		ForceQuery:  input.ForceQuery,
+		RawQuery:    input.RawQuery,
+		Fragment:    input.Fragment,
+		RawFragment: input.RawFragment,
+	}
 }


### PR DESCRIPTION
If the `tokenUrl` of the client credential flow is a relative path it should be prepended with the base server URL