### PR TITLE
Use Retry-After header to wait for the next retry if exists

### DIFF
--- a/.github/scripts/plugin-manifest.yaml
+++ b/.github/scripts/plugin-manifest.yaml
@@ -7,35 +7,35 @@ platforms:
   - selector: darwin-arm64
     uri: "https://github.com/hasura/ndc-http/releases/download/${CLI_VERSION}/ndc-http-schema-darwin-arm64"
     sha256: "${MACOS_ARM64_SHA256}"
-    bin: "ndc-http-schema"
+    bin: "ndc-http"
     files:
       - from: "./ndc-http-schema-darwin-arm64"
-        to: "ndc-http-schema"
+        to: "ndc-http"
   - selector: linux-arm64
     uri: "https://github.com/hasura/ndc-http/releases/download/${CLI_VERSION}/ndc-http-schema-linux-arm64"
     sha256: "${LINUX_ARM64_SHA256}"
-    bin: "ndc-http-schema"
+    bin: "ndc-http"
     files:
       - from: "./ndc-http-schema-linux-arm64"
-        to: "ndc-http-schema"
+        to: "ndc-http"
   - selector: darwin-amd64
     uri: "https://github.com/hasura/ndc-http/releases/download/${CLI_VERSION}/ndc-http-schema-darwin-amd64"
     sha256: "${MACOS_AMD64_SHA256}"
-    bin: "ndc-http-schema"
+    bin: "ndc-http"
     files:
       - from: "./ndc-http-schema-darwin-amd64"
-        to: "ndc-http-schema"
+        to: "ndc-http"
   - selector: windows-amd64
     uri: "https://github.com/hasura/ndc-http/releases/download/${CLI_VERSION}/ndc-http-schema-windows-amd64.exe"
     sha256: "${WINDOWS_AMD64_SHA256}"
-    bin: "ndc-http-schema.exe"
+    bin: "ndc-http.exe"
     files:
       - from: "./ndc-http-schema-windows-amd64.exe"
-        to: "ndc-http-schema.exe"
+        to: "ndc-http.exe"
   - selector: linux-amd64
     uri: "https://github.com/hasura/ndc-http/releases/download/${CLI_VERSION}/ndc-http-schema-linux-amd64"
     sha256: "${LINUX_AMD64_SHA256}"
-    bin: "ndc-http-schema"
+    bin: "ndc-http"
     files:
       - from: "./ndc-http-schema-linux-amd64"
-        to: "ndc-http-schema"
+        to: "ndc-http"

--- a/.github/scripts/plugin-manifest.yaml
+++ b/.github/scripts/plugin-manifest.yaml
@@ -7,35 +7,35 @@ platforms:
   - selector: darwin-arm64
     uri: "https://github.com/hasura/ndc-http/releases/download/${CLI_VERSION}/ndc-http-schema-darwin-arm64"
     sha256: "${MACOS_ARM64_SHA256}"
-    bin: "ndc-http"
+    bin: "hasura-ndc-http"
     files:
       - from: "./ndc-http-schema-darwin-arm64"
-        to: "ndc-http"
+        to: "hasura-ndc-http"
   - selector: linux-arm64
     uri: "https://github.com/hasura/ndc-http/releases/download/${CLI_VERSION}/ndc-http-schema-linux-arm64"
     sha256: "${LINUX_ARM64_SHA256}"
-    bin: "ndc-http"
+    bin: "hasura-ndc-http"
     files:
       - from: "./ndc-http-schema-linux-arm64"
-        to: "ndc-http"
+        to: "hasura-ndc-http"
   - selector: darwin-amd64
     uri: "https://github.com/hasura/ndc-http/releases/download/${CLI_VERSION}/ndc-http-schema-darwin-amd64"
     sha256: "${MACOS_AMD64_SHA256}"
-    bin: "ndc-http"
+    bin: "hasura-ndc-http"
     files:
       - from: "./ndc-http-schema-darwin-amd64"
-        to: "ndc-http"
+        to: "hasura-ndc-http"
   - selector: windows-amd64
     uri: "https://github.com/hasura/ndc-http/releases/download/${CLI_VERSION}/ndc-http-schema-windows-amd64.exe"
     sha256: "${WINDOWS_AMD64_SHA256}"
-    bin: "ndc-http.exe"
+    bin: "hasura-ndc-http.exe"
     files:
       - from: "./ndc-http-schema-windows-amd64.exe"
-        to: "ndc-http.exe"
+        to: "hasura-ndc-http.exe"
   - selector: linux-amd64
     uri: "https://github.com/hasura/ndc-http/releases/download/${CLI_VERSION}/ndc-http-schema-linux-amd64"
     sha256: "${LINUX_AMD64_SHA256}"
-    bin: "ndc-http"
+    bin: "hasura-ndc-http"
     files:
       - from: "./ndc-http-schema-linux-amd64"
-        to: "ndc-http"
+        to: "hasura-ndc-http"

--- a/connector-definition/.hasura-connector/connector-metadata.yaml
+++ b/connector-definition/.hasura-connector/connector-metadata.yaml
@@ -3,8 +3,8 @@ packagingDefinition:
   dockerImage: ghcr.io/hasura/ndc-http:{{VERSION}}
 supportedEnvironmentVariables: []
 commands:
-  update: ndc-http-schema update
-  upgradeConfiguration: ndc-http-schema version
+  update: ndc-http update
+  upgradeConfiguration: ndc-http version
 cliPlugin:
   name: ndc-http
   version: "{{VERSION}}"

--- a/connector-definition/.hasura-connector/connector-metadata.yaml
+++ b/connector-definition/.hasura-connector/connector-metadata.yaml
@@ -3,8 +3,8 @@ packagingDefinition:
   dockerImage: ghcr.io/hasura/ndc-http:{{VERSION}}
 supportedEnvironmentVariables: []
 commands:
-  update: ndc-http update
-  upgradeConfiguration: ndc-http version
+  update: hasura-ndc-http update
+  upgradeConfiguration: hasura-ndc-http version
 cliPlugin:
   name: ndc-http
   version: "{{VERSION}}"

--- a/connector/internal/client.go
+++ b/connector/internal/client.go
@@ -501,9 +501,11 @@ func (client *HTTPClient) createHeaderForwardingResponse(result any, rawHeaders 
 	}
 }
 
-// The HTTP Retry-After response header indicates how long the user agent should wait before making a follow-up request.
+// The HTTP [Retry-After] response header indicates how long the user agent should wait before making a follow-up request.
 // The client finds this header if exist and decodes to duration.
 // If the header doesn't exist or there is any error happened, fallback to the retry delay setting.
+//
+// [Retry-After]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
 func (client *HTTPClient) getRetryDelay(resp *http.Response, options rest.RuntimeSettings) (time.Duration, bool) {
 	if rawRetryAfter := resp.Header.Get("Retry-After"); rawRetryAfter != "" {
 		// A non-negative decimal integer indicating the seconds to delay after the response is received.
@@ -515,7 +517,7 @@ func (client *HTTPClient) getRetryDelay(resp *http.Response, options rest.Runtim
 		// A date after which to retry, e.g. Tue, 29 Oct 2024 16:56:32 GMT
 		retryTime, err := time.Parse(time.RFC1123, rawRetryAfter)
 		if err == nil && retryTime.After(time.Now()) {
-			duration := retryTime.Sub(time.Now())
+			duration := time.Until(retryTime)
 
 			return duration, options.Timeout == 0 || duration < (time.Duration(options.Timeout)*time.Second)
 		}

--- a/connector/internal/client.go
+++ b/connector/internal/client.go
@@ -206,9 +206,8 @@ func (client *HTTPClient) sendSingle(ctx context.Context, request *RetryableRequ
 	var cancel context.CancelFunc
 
 	times := int(request.Runtime.Retry.Times)
-	delayMs := int(math.Max(float64(request.Runtime.Retry.Delay), 100))
 	for i := 0; i <= times; i++ {
-		resp, errorBytes, cancel, err = client.doRequest(ctx, request, port, i) //nolint:all
+		resp, errorBytes, cancel, err = client.doRequest(ctx, request, port, i) //nolint:bodyclose
 		if err != nil {
 			span.SetStatus(codes.Error, "failed to execute the request")
 			span.RecordError(err)
@@ -230,7 +229,14 @@ func (client *HTTPClient) sendSingle(ctx context.Context, request *RetryableRequ
 			)
 		}
 
-		time.Sleep(time.Duration(delayMs) * time.Millisecond)
+		nextRetryDuration, ok := client.getRetryDelay(resp, request.Runtime)
+		if !ok {
+			// The next retry time is greater than the timeout.
+			// The client shouldn't uselessly lock the entire request until reaching timeout.
+			break
+		}
+
+		time.Sleep(nextRetryDuration)
 	}
 
 	defer cancel()
@@ -493,6 +499,31 @@ func (client *HTTPClient) createHeaderForwardingResponse(result any, rawHeaders 
 		forwardHeaders.ResponseHeaders.HeadersField: headers,
 		forwardHeaders.ResponseHeaders.ResultField:  result,
 	}
+}
+
+// The HTTP Retry-After response header indicates how long the user agent should wait before making a follow-up request.
+// The client finds this header if exist and decodes to duration.
+// If the header doesn't exist or there is any error happened, fallback to the retry delay setting.
+func (client *HTTPClient) getRetryDelay(resp *http.Response, options rest.RuntimeSettings) (time.Duration, bool) {
+	if rawRetryAfter := resp.Header.Get("Retry-After"); rawRetryAfter != "" {
+		// A non-negative decimal integer indicating the seconds to delay after the response is received.
+		retryAfterSecs, err := strconv.ParseInt(rawRetryAfter, 10, 32)
+		if err == nil && retryAfterSecs > 0 {
+			return time.Second * time.Duration(retryAfterSecs), options.Timeout == 0 || retryAfterSecs < int64(options.Timeout)
+		}
+
+		// A date after which to retry, e.g. Tue, 29 Oct 2024 16:56:32 GMT
+		retryTime, err := time.Parse(time.RFC1123, rawRetryAfter)
+		if err == nil && retryTime.After(time.Now()) {
+			duration := retryTime.Sub(time.Now())
+
+			return duration, options.Timeout == 0 || duration < (time.Duration(options.Timeout)*time.Second)
+		}
+	}
+
+	canRetry := options.Timeout == 0 || (options.Retry.Delay/1000 < options.Timeout)
+
+	return time.Duration(math.Max(float64(options.Retry.Delay), 100)) * time.Millisecond, canRetry
 }
 
 func parseContentType(input string) string {

--- a/connector/testdata/auth/schema.yaml
+++ b/connector/testdata/auth/schema.yaml
@@ -108,7 +108,17 @@ functions:
       security: []
       response:
         contentType: application/json
-    arguments: {}
+    arguments:
+      retry_after:
+        type:
+          type: nullable
+          underlying_type:
+            name: Boolean
+            type: named
+        http:
+          in: query
+          schema:
+            type: [boolean]
     result_type:
       element_type:
         name: Pet

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,8 @@ files:
       times:
         value: 1
       delay:
-        # delay between each retry in milliseconds
+        # The default delay between each retry in milliseconds.
+        # The connector prefers the Retry-After header in the response if exists
         value: 500
       httpStatus: [429, 500, 502, 503]
 ```


### PR DESCRIPTION
Use the `Retry-After` header to wait for the next retry if exists.
Fallback to the default retry delay setting.