### PR TITLE
feat: add setting to disable sendHttpRequest

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -22,7 +22,7 @@ type HTTPConnector struct {
 	rawSchema           *schema.RawSchemaResponse
 	httpClient          *http.Client
 	upstreams           *internal.UpstreamManager
-	procSendHttpRequest rest.OperationInfo
+	procSendHttpRequest *rest.OperationInfo
 }
 
 // NewHTTPConnector creates a HTTP connector instance.

--- a/connector/mutation.go
+++ b/connector/mutation.go
@@ -112,9 +112,15 @@ func (c *HTTPConnector) execMutationOperation(parentCtx context.Context, state *
 	var requests *internal.RequestBuilderResults
 	var err error
 	if operation.Name == internal.ProcedureSendHTTPRequest {
+		if c.procSendHttpRequest == nil {
+			span.SetStatus(codes.Error, internal.ProcedureSendHTTPRequest+" mutation is disabled")
+
+			return nil, schema.InternalServerError(internal.ProcedureSendHTTPRequest+" mutation is disabled. Set runtime.enableRawRequest=true to enable this operation", nil)
+		}
+
 		requests, err = internal.NewRawRequestBuilder(operation, c.config.ForwardHeaders).Build()
 		if err == nil {
-			requests.Operation = &c.procSendHttpRequest
+			requests.Operation = c.procSendHttpRequest
 		}
 	} else {
 		requests, err = c.explainProcedure(&operation)

--- a/connector/schema.go
+++ b/connector/schema.go
@@ -33,7 +33,7 @@ func (c *HTTPConnector) ApplyNDCHttpSchemas(ctx context.Context, schemas []confi
 		}
 	}
 
-	ndcSchema, procSendHttp := internal.ApplyDefaultConnectorSchema(httpSchema.ToSchemaResponse(), config.ForwardHeaders)
+	ndcSchema, procSendHttp := internal.ApplyDefaultConnectorSchema(httpSchema.ToSchemaResponse(), config)
 	schemaBytes, err := json.Marshal(internal.ApplyPromptQLSettingsToSchema(ndcSchema, c.upstreams.RuntimeSettings))
 	if err != nil {
 		return err

--- a/connector/testdata/compression/config.yaml
+++ b/connector/testdata/compression/config.yaml
@@ -9,6 +9,7 @@ concurrency:
   mutation: 1
   http: 1
 runtime:
+  enableRawRequest: false
   stringifyJson:
     env: HTTP_STRINGIFY_JSON
 files:

--- a/ndc-http-schema/configuration/types.go
+++ b/ndc-http-schema/configuration/types.go
@@ -299,19 +299,25 @@ var httpSingleOptionsArgument = rest.ArgumentInfo{
 
 // RawRuntimeSettings hold raw runtime settings.
 type RawRuntimeSettings struct {
+	// Enable the sendHttpRequest operation.
+	EnableRawRequest *bool `json:"enableRawRequest,omitempty" yaml:"enableRawRequest,omitempty"`
 	// Treat the JSON scalar as a json string
 	StringifyJSON *utils.EnvBool `json:"stringifyJson,omitempty" yaml:"stringifyJson,omitempty"`
 }
 
 // RuntimeSettings hold optional runtime settings.
 type RuntimeSettings struct {
+	// Enable the sendHttpRequest operation.
+	EnableRawRequest bool `json:"enableRawRequest,omitempty" yaml:"enableRawRequest,omitempty"`
 	// Treat the JSON scalar as a json string
 	StringifyJSON bool `json:"stringifyJson,omitempty" yaml:"stringifyJson,omitempty"`
 }
 
 // Validate validates and returns validated settings.
 func (rs RawRuntimeSettings) Validate() (*RuntimeSettings, error) {
-	result := RuntimeSettings{}
+	result := RuntimeSettings{
+		EnableRawRequest: rs.EnableRawRequest == nil || *rs.EnableRawRequest,
+	}
 
 	if rs.StringifyJSON != nil {
 		stringifyJson, err := rs.StringifyJSON.GetOrDefault(false)

--- a/ndc-http-schema/jsonschema/configuration.schema.json
+++ b/ndc-http-schema/jsonschema/configuration.schema.json
@@ -283,6 +283,10 @@
     },
     "RawRuntimeSettings": {
       "properties": {
+        "enableRawRequest": {
+          "type": "boolean",
+          "description": "Enable the sendHttpRequest operation."
+        },
         "stringifyJson": {
           "$ref": "#/$defs/EnvBool",
           "description": "Treat the JSON scalar as a json string"


### PR DESCRIPTION
Add a new setting `runtime.enableRawRequest: boolean` to allow turning on or off the `sendHttpRequest` mutation. The default value is `true`.