### PR TITLE
cd: add native toolchain definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,10 @@ build-cli:
 	go build -o _output/ndc-http-schema ./ndc-http-schema
 
 .PHONY: ci-build-cli
-ci-build-cli: export CGO_ENABLED=0
 ci-build-cli: clean
 	cd ./ndc-http-schema && \
 	go get github.com/mitchellh/gox && \
-	go run github.com/mitchellh/gox -ldflags '-X github.com/hasura/ndc-http/ndc-http-schema/version.BuildVersion=$(VERSION) -s -w -extldflags "-static"' \
+	CGO_ENABLED=0 go run github.com/mitchellh/gox -ldflags '-X github.com/hasura/ndc-http/ndc-http-schema/version.BuildVersion=$(VERSION) -s -w -extldflags "-static"' \
 		-osarch="linux/amd64 darwin/amd64 windows/amd64 darwin/arm64 linux/arm64" \
 		-output="../$(OUTPUT_DIR)/ndc-http-schema-{{.OS}}-{{.Arch}}" \
 		.

--- a/connector-definition/.hasura-connector/connector-metadata.yaml
+++ b/connector-definition/.hasura-connector/connector-metadata.yaml
@@ -1,7 +1,38 @@
+version: v2
+ndcSpecGeneration: v0.2
 packagingDefinition:
   type: PrebuiltDockerImage
   dockerImage: ghcr.io/hasura/ndc-http:{{VERSION}}
 supportedEnvironmentVariables: []
+nativeToolchainDefinition:
+  commands:
+    start:
+      type: ShellScript
+      bash: |
+        #!/usr/bin/env bash
+        set -eu -o pipefail        
+        HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" "$HASURA_DDN_NATIVE_CONNECTOR_DIR/ndc-cli" serve
+      powershell: |
+        $ErrorActionPreference = "Stop"
+        $env:HASURA_CONFIGURATION_DIRECTORY="$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"; & "$env:HASURA_DDN_NATIVE_CONNECTOR_DIR\ndc-cli.exe" serve
+    update:
+      type: ShellScript
+      bash: |
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        "$HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR/hasura-ndc-http" update
+      powershell: |
+        $ErrorActionPreference = "Stop"
+        & "$env:HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR\hasura-ndc-http.exe" update
+    watch:
+      type: ShellScript
+      bash: |
+        #!/usr/bin/env bash
+        echo "Watch is not supported for this connector"
+        exit 1
+      powershell: |
+        Write-Output "Watch is not supported for this connector"
+        exit 1
 commands:
   update: hasura-ndc-http update
   upgradeConfiguration: hasura-ndc-http version
@@ -13,3 +44,4 @@ dockerComposeWatch:
   - path: .
     target: /etc/connector
     action: sync+restart
+documentationPage: "https://hasura.io/docs/3.0/how-to-build-with-ddn/with-http"


### PR DESCRIPTION
This pull request introduces updates to the build process, configuration metadata, and documentation for the `ndc-http-schema` project. The changes improve the build pipeline, enhance the connector's metadata with native toolchain definitions, and add a documentation link for better user guidance.

### Build process improvements:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L48-R51): Moved the `CGO_ENABLED=0` environment variable directly into the `ci-build-cli` target command instead of exporting it globally, ensuring it applies only to this specific build step.

### Connector metadata enhancements:
* [`connector-definition/.hasura-connector/connector-metadata.yaml`](diffhunk://#diff-936a212963c1f88878878d1439d002ef0766313668f53dc6f7899ef117561499R1-R35): Added a `nativeToolchainDefinition` section with shell and PowerShell commands for `start`, `update`, and `watch` operations, providing better support for native toolchain workflows.

### Documentation updates:
* [`connector-definition/.hasura-connector/connector-metadata.yaml`](diffhunk://#diff-936a212963c1f88878878d1439d002ef0766313668f53dc6f7899ef117561499R47): Added a `documentationPage` field linking to the relevant Hasura documentation for building with DDN using HTTP.