### PR TITLE
fix: update deflate compressor to use flate instead of zlib

### DIFF
--- a/exhttp/compression/deflate.go
+++ b/exhttp/compression/deflate.go
@@ -1,7 +1,7 @@
 package compression
 
 import (
-	"compress/zlib"
+	"compress/flate"
 	"io"
 )
 
@@ -12,9 +12,12 @@ const (
 // DeflateCompressor implements the compression handler for deflate encoding.
 type DeflateCompressor struct{}
 
-// Compress the reader content with gzip encoding.
+// Compress the reader content with deflate encoding.
 func (dc DeflateCompressor) Compress(w io.Writer, src io.Reader) (int64, error) {
-	zw := zlib.NewWriter(w)
+	zw, err := flate.NewWriter(w, flate.DefaultCompression)
+	if err != nil {
+		return 0, err
+	}
 
 	size, err := io.Copy(zw, src)
 	_ = zw.Close()
@@ -22,12 +25,9 @@ func (dc DeflateCompressor) Compress(w io.Writer, src io.Reader) (int64, error) 
 	return size, err
 }
 
-// Decompress the reader content with gzip encoding.
+// Decompress the reader content with deflate encoding.
 func (dc DeflateCompressor) Decompress(reader io.ReadCloser) (io.ReadCloser, error) {
-	compressionReader, err := zlib.NewReader(reader)
-	if err != nil {
-		return nil, err
-	}
+	compressionReader := flate.NewReader(reader)
 
 	return readCloserWrapper{
 		CompressionReader: compressionReader,


### PR DESCRIPTION
This pull request updates the implementation of the `DeflateCompressor` in the `exhttp/compression/deflate.go` file to use the `compress/flate` package instead of `compress/zlib` for both compression and decompression. This change directly affects how deflate encoding is handled in the codebase.

Compression and decompression implementation update:

* Switched from using `zlib.NewWriter`/`zlib.NewReader` to `flate.NewWriter`/`flate.NewReader` for deflate compression and decompression, updating error handling and resource management accordingly. [[1]](diffhunk://#diff-a45c1543d51c712beaa9c267432565499f5bb4588cbe42d2d0bb98316117906bL4-R4) [[2]](diffhunk://#diff-a45c1543d51c712beaa9c267432565499f5bb4588cbe42d2d0bb98316117906bL15-R30)